### PR TITLE
Add support for lyric files

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,7 +362,6 @@ The `metadata` object in [`session/update`](#server--client-sessionupdate) has t
   - `album_artist?`: string | null
   - `album?`: string | null
   - `artwork_url?`: string | null
-  - `lyric_url?`: string | null
   - `year?`: number | null
   - `track?`: number | null
   - `track_progress?`: number | null - in seconds


### PR DESCRIPTION
This draft PR introduces protocol support for lyric files.

There are several decisions to be made:
- Is support for various lyric file types necessary?  Or should just LRC be supported?
- What data should be sent to the client and when?
  - Should the server parse the file and send the timestamped lyrics?  
    - This would be great for low power devices or devices with limited screen space.
  - Should the entire LRC file be sent to the device to parse on its own? 
    - This would be great for a device that wants to display the previous lyrics and future lyrics alongside the current lyrics.  Like this:
<img width="637" height="1098" alt="484230538-0bd30346-5320-4f9d-a85f-b0be8948cd6b" src="https://github.com/user-attachments/assets/4bbcba0c-ca12-4c1e-8259-0d121ae9a5c6" />

 