### PR TITLE
Make mDNS section more specific

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,29 @@ Resonate is a multi-room music experience protocol. The goal of the protocol is 
 
 ## Establishing a Connection
 
-Clients announce their presence via mDNS using the service type `_resonate._tcp`.
+While custom connection methods are possible for specialized use cases (like remotely accessible web-browsers, mobile apps), Resonate requires support for standardized connection establishment. **Servers must support both methods** described below, while **clients must support exactly one**.
 
-Resonate communicates over WebSockets on the path `/resonate`. Recommended port is `8927`.
+### Server Initiated Connections
 
-Resonate servers support connections from browsers, mobile apps, and other WebSocket-capable clients.
+Clients announce their presence via mDNS using:
+- Service type: `_resonate._tcp`
+- Port: The port the Resonate client is listening on (recommended: `8927`)
+- TXT record: `path=/resonate`
+
+The server discovers available clients through mDNS and connects to each client via WebSocket using the advertised address and path.
+
+### Client Initiated Connections
+
+If clients prefer to initiate the connection instead of waiting for the server to connect, the server must be discoverable via mDNS using:
+- Service type: `_resonate_server._tcp`
+- Port: The port the Resonate server is listening on (recommended: `8927`)
+- TXT record: `path=/resonate`
+
+Clients discover the server through mDNS and initiate a WebSocket connection using the advertised address and path.
+
+**Note:** Do not advertise `_resonate._tcp` if the client plans to initiate the connection.
+
+**Note:** After this point, Resonate works independently of how the connection was established. The Resonate client is always the consumer of data like audio or metadata, regardless of who initiated the connection.
 
 ## Communication
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Resonate is a multi-room music experience protocol. The goal of the protocol is 
 
 ## Establishing a Connection
 
-While custom connection methods are possible for specialized use cases (like remotely accessible web-browsers, mobile apps), Resonate requires support for standardized connection establishment. **Servers must support both methods** described below, while **clients must support exactly one**.
+While custom connection methods are possible for specialized use cases (like remotely accessible web-browsers, mobile apps), Resonate requires support for standardized connection establishment. **Servers must support both methods** described below, while **clients must support exactly one** (unless the use case falls under the specialized category).
 
 ### Server Initiated Connections
 


### PR DESCRIPTION
mDNS types were not yet fully standardized and were missing the `_resonate_server` type.