### PR TITLE
Support player volume changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ The `player_support` object in [`client/hello`](#client--server-clienthello) has
   - `support_sample_rates`: number[] - supported sample rates in priority order
   - `support_bit_depth`: number[] - bit depth in priority order
   - `buffer_capacity`: number - buffer capacity size in bytes
+  - `supported_commands`: string[] - subset of: `volume`, `mute`
 
 ### Client → Server: `player/update`
 
@@ -237,7 +238,7 @@ Response: `stream/update` with the new format.
 
 Request the player to perform an action, e.g., change volume or mute state.
 
-- `command`: 'volume' | 'mute'
+- `command`: 'volume' | 'mute' - must be one of the values listed in `supported_commands` in the [`player_support`](#client--server-clienthello-player-support-object) object in the [`client/hello`](#client--server-clienthello) message
 - `volume?`: number - volume range 0-100, only set if `command` is `volume`
 - `mute?`: boolean - true to mute, false to unmute, only set if `command` is `mute`
 


### PR DESCRIPTION
This PR add `player/command` to handle volume changes initiated by the server.

Players without volume/mute support are supported by making `player/command`s optional through `supported_commands` in the players `client/hello` message.

Resolves: 
> Server -> client volume/mute messages were removed and need replacing. How should these messages be named? (They only should be sent to clients with the player role)

From:
- https://github.com/Resonate-Protocol/spec/pull/3

This PR also specifies that `player/update` should always be sent, so behavior is consistent across player implementations.