### PR TITLE
Make specification less ambiguous

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ The `metadata` object in [`stream/update`](#server--client-streamupdate) has thi
 
 The `metadata` object in [`session/update`](#server--client-sessionupdate) has this structure:
 
-Clients can calculate the current track position at any time using the last received values: `current_track_progress_ms = max(min(metadata.track_progress + (current_time - metadata.timestamp) / 1000 * metadata.playback_speed, metadata.track_duration), 0)`
+Clients can calculate the current track position at any time using the last received values: `current_track_progress_ms = max(min(metadata.track_progress + (current_time - metadata.timestamp) * metadata.playback_speed / 1000000, metadata.track_duration), 0)`
 
 - `metadata`: object
   - `timestamp`: integer - server clock time in microseconds for when this metadata is valid


### PR DESCRIPTION
This PR adjusts the spec to be less ambiguous in places where it could be interpreted in multiple ways.
Specifically:
- Specify constraints of the server's clock: monotonic, in microseconds, but epoch is application specific
- Explain when then the audio chunk should leave the device
- Add descriptions to metadata properties
- Add example formula for how to calculate the current tracks progress
- Replace uses of `number` with `integer` and `float`
- Require strict message order for the initial handshake (like it was already shown in the mermaid diagram)
- Exactly define how `buffer_capacity` will be used
- Explain use cases of `artwork_url` to differentiate between binary Media Art messages
- replace floating point `playback_speed` with a integer