### PR TITLE
Promote `group/update` to a core message and add `group_name`

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,6 @@ No payload.
 
 Delta updates that must be merged into existing state. Fields set to `null` should be nullified. The server should null the metadata whenever a session is ended.
 
-- `group_id`: string - group identifier
 - `playback_state?`: 'playing' | 'paused' | 'stopped' - only sent to clients with `controller` or `metadata` roles
 - `metadata?`: object - only sent to clients with `metadata` role ([see metadata object details](#server--client-sessionupdate-metadata-object))
 
@@ -239,6 +238,7 @@ State update of the group this client is part of.
 
 Delta updates that must be merged into existing state. Fields set to `null` should be nullified. The server should null the metadata whenever a session is ended.
 
+- `group_id?`: string - group identifier
 - `controller?`: object - only sent to clients with `controller` role ([see controller object details](#server--client-groupupdate-controller-object))
 
 
@@ -353,6 +353,7 @@ The `controller` object in [`group/update`](#server--client-groupupdate) has thi
   - `supported_commands`: string[] - subset of: 'play' | 'pause' | 'stop' | 'next' | 'previous' | 'volume' | 'mute' | `repeat_off` | `repeat_one` | `repeat_all` | `shuffle` | `unshuffle`
   - `volume`: integer - volume of the whole group, range 0-100
   - `muted`: boolean - mute state of the whole group
+
 
 ## Metadata messages
 This section describes messages specific to clients with the `metadata` role, which handle display of track information, artwork, and playback state. Metadata clients receive session updates with track details and can optionally receive artwork in their preferred format and resolution.

--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ State update of the group this client is part of.
 Delta updates that must be merged into existing state. Fields set to `null` should be nullified. The server should null the metadata whenever a session is ended.
 
 - `group_id?`: string - group identifier
+- `group_name?`: string - friendly name of the group
 - `controller?`: object - only sent to clients with `controller` role ([see controller object details](#server--client-groupupdate-controller-object))
 
 

--- a/README.md
+++ b/README.md
@@ -233,6 +233,15 @@ Delta updates that must be merged into existing state. Fields set to `null` shou
 - `playback_state?`: 'playing' | 'paused' | 'stopped' - only sent to clients with `controller` or `metadata` roles
 - `metadata?`: object - only sent to clients with `metadata` role ([see metadata object details](#server--client-sessionupdate-metadata-object))
 
+### Server → Client: `group/update`
+
+State update of the group this client is part of.
+
+Delta updates that must be merged into existing state. Fields set to `null` should be nullified. The server should null the metadata whenever a session is ended.
+
+- `controller?`: object - only sent to clients with `controller` role ([see controller object details](#server--client-groupupdate-controller-object))
+
+
 ## Player messages
 This section describes messages specific to clients with the `player` role, which handle audio output and synchronized playback. Player clients receive timestamped audio data, manage their own volume and mute state, and can request different audio formats based on their capabilities and current conditions.
 
@@ -336,14 +345,14 @@ For a client without the `player` role this will:
 
 No payload.
 
-### Server → Client: `group/update`
+### Server → Client: `group/update` controller object
 
-Group state update.
+The `controller` object in [`group/update`](#server--client-groupupdate) has this structure:
 
-- `supported_commands`: string[] - subset of: 'play' | 'pause' | 'stop' | 'next' | 'previous' | 'volume' | 'mute' | `repeat_off` | `repeat_one` | `repeat_all` | `shuffle` | `unshuffle` 
-- `volume`: integer - range 0-100
-- `muted`: boolean - mute state
-
+- `controller`: object
+  - `supported_commands`: string[] - subset of: 'play' | 'pause' | 'stop' | 'next' | 'previous' | 'volume' | 'mute' | `repeat_off` | `repeat_one` | `repeat_all` | `shuffle` | `unshuffle`
+  - `volume`: integer - volume of the whole group, range 0-100
+  - `muted`: boolean - mute state of the whole group
 
 ## Metadata messages
 This section describes messages specific to clients with the `metadata` role, which handle display of track information, artwork, and playback state. Metadata clients receive session updates with track details and can optionally receive artwork in their preferred format and resolution.


### PR DESCRIPTION
To avoid having a controller role specific `group/update` message, this PR moves it into the core message set.
This allows us to move the `group_id` from the `session/update` to the `group/update` message.
Additionally `group_name` was also so clients with displays can also show a human readable group name.

While `group_id` and `group_name` will be sent to all clients. Controller specific information like the volume and list of supported commands will still only available to controller roles.