### PR TITLE
Create new `artwork` role

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,10 +387,9 @@ This section describes messages specific to clients with the `artwork` role, whi
 The `artwork_support` object in [`client/hello`](#client--server-clienthello) has this structure:
 
 - `artwork_support`: object
-  - `support_picture_formats`: object[] - list of supported artwork formats in priority order (must have at least one format, first is preferred)
-    - `format`: 'jpeg' | 'png' | 'bmp' - image format identifier
-    - `media_width`: integer - max width in pixels
-    - `media_height`: integer - max height in pixels
+  - `format`: 'jpeg' | 'png' | 'bmp' - image format identifier
+  - `media_width`: integer - max width in pixels
+  - `media_height`: integer - max height in pixels
 
 **Note:** The server will scale images to fit within the specified dimensions while preserving aspect ratio.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Resonate is a multi-room music experience protocol. The goal of the protocol is 
   - **Visualizer** - visualizes music. Has preferred format for audio features
 - **Resonate Group** - a group of clients. Each client belongs to exactly one group, and every group has at least one client. Every group has a unique identifier. Each group has the following states: list of member clients, volume, mute, and active session (may be null)
 - **Resonate Session** - details the currently playing media and its playback state. Has associated metadata and a unique identifier. Each session is associated with exactly one group
-- **Resonate Stream** - client-specific details on how the server is formatting and sending binary data. Each client receives its own independently encoded stream based on its capabilities and preferences. The server sends audio chunks as far ahead as the client's buffer capacity allows
+- **Resonate Stream** - client-specific details on how the server is formatting and sending binary data. Each client receives its own independently encoded stream based on its capabilities and preferences. For players, the server sends audio chunks as far ahead as the client's buffer capacity allows. For metadata clients requesting artwork, the server creates a session to send album artwork and other visual metadata
 
 ## Establishing a Connection
 
@@ -218,6 +218,17 @@ When the format of the messages changes for the ongoing stream. Deltas updating 
 - `metadata?`: object - only sent to clients with the `metadata` role that specified supported picture formats ([see metadata object details](#server--client-streamupdate-metadata-object))
 - `visualizer?`: object - only sent to clients with the `visualizer` role ([see visualizer object details](#server--client-streamupdate-visualizer-object))
 
+### Client → Server: `stream/request-format`
+
+Request different stream format (upgrade or downgrade). Available for clients with the `player` or `metadata` role.
+
+- `player?`: object - only for clients with the `player` role ([see player object details](#client--server-streamrequest-format-player-object))
+- `metadata?`: object - only for clients with the `metadata` role ([see metadata object details](#client--server-streamrequest-format-metadata-object))
+
+Response: [`stream/update`](#server--client-streamupdate) with the new format for the requested role(s).
+
+**Note:** Clients should use this message to adapt to changing network conditions, CPU constraints, or display requirements. The server maintains separate encoding for each client, allowing heterogeneous device capabilities within the same group.
+
 ### Server → Client: `stream/end`
 
 Player should stop streaming and clear buffers - report idle state.
@@ -259,18 +270,15 @@ Must be sent immediately after receiving `server/hello` and whenever any state c
 - `volume`: integer - range 0-100
 - `muted`: boolean - mute state
 
-### Client → Server: `stream/request-format`
+### Client → Server: `stream/request-format` player object
 
-Request different stream format (upgrade or downgrade). Only for clients with the `player` role.
+The `player` object in [`stream/request-format`](#client--server-streamrequest-format) has this structure:
 
-- `codec?`: string - requested codec
-- `sample_rate?`: integer - requested sample rate
-- `channels?`: integer - requested channels
-- `bit_depth?`: integer - requested bit depth
-
-Response: `stream/update` with the new format.
-
-**Note:** Clients should use this message to adapt to changing network conditions or CPU constraints. The server maintains separate encoding for each client, allowing heterogeneous device capabilities within the same group.
+- `player`: object
+  - `codec?`: string - requested codec
+  - `channels?`: integer - requested channels
+  - `sample_rate?`: integer - requested sample rate
+  - `bit_depth?`: integer - requested bit depth
 
 ### Server → Client: `player/command`
 
@@ -353,23 +361,39 @@ This section describes messages specific to clients with the `metadata` role, wh
 The `metadata_support` object in [`client/hello`](#client--server-clienthello) has this structure:
 
 - `metadata_support`: object
-  - `support_picture_formats`: string[] - supported media art image formats (empty array if no art desired)
-  - `media_width?`: integer - max width in pixels (if only width set, scales preserving aspect ratio)
-  - `media_height?`: integer - max height in pixels (if only height set, scales preserving aspect ratio)
+  - `support_picture_formats`: object[] - list of supported artwork formats in priority order (empty array if no art desired, first is preferred)
+    - `format`: 'jpeg' | 'png' | 'bmp' - image format identifier
+    - `media_width`: integer - max width in pixels
+    - `media_height`: integer - max height in pixels
+
+**Note:** The server will scale images to fit within the specified dimensions while preserving aspect ratio.
+
+### Client → Server: `stream/request-format` metadata object
+
+The `metadata` object in [`stream/request-format`](#client--server-streamrequest-format) has this structure:
+
+- `metadata`: object
+  - `art_format?`: 'jpeg' | 'png' | 'bmp' - requested image format identifier
+  - `media_width?`: integer - requested max width in pixels
+  - `media_height?`: integer - requested max height in pixels
 
 ### Server → Client: `stream/start` metadata object
 
 The `metadata` object in [`stream/start`](#server--client-streamstart) (sent to clients that specified supported picture formats) has this structure:
 
 - `metadata`: object
-  - `art_format`: 'bmp' | 'jpeg' | 'png' - format of the encoded image
+  - `art_format`: 'jpeg' | 'png' | 'bmp' - format of the encoded image (must match one from client's `support_picture_formats`)
+  - `art_width`: integer - width in pixels of the encoded image
+  - `art_height`: integer - height in pixels of the encoded image
 
 ### Server → Client: `stream/update` metadata object
 
 The `metadata` object in [`stream/update`](#server--client-streamupdate) has this structure with delta updates:
 
 - `metadata`: object
-  - `art_format`: 'bmp' | 'jpeg' | 'png' - format of the encoded image
+  - `art_format?`: 'jpeg' | 'png' | 'bmp' - format of the encoded image (must match one from client's `support_picture_formats`)
+  - `art_width?`: integer - width in pixels of the encoded image
+  - `art_height?`: integer - height in pixels of the encoded image
 
 ### Server → Client: `session/update` metadata object
 

--- a/README.md
+++ b/README.md
@@ -402,6 +402,8 @@ Binary messages should be rejected if there is no active stream.
 
 The timestamp indicates when this artwork becomes valid for display.
 
+**Clearing artwork:** To clear the currently displayed artwork, the server sends an empty binary message (only the message type byte and timestamp, with no image data).
+
 ## Visualizer messages
 This section describes messages specific to clients with the `visualizer` role, which create visual representations of the audio being played. Visualizer clients receive audio analysis data like FFT information that corresponds to the current audio timeline.
 


### PR DESCRIPTION
This PR introduces a dedicated `artwork` role as discussed on [discord](https://discord.com/channels/753947050995089438/1369735163629801532/1424502752310198284), separating artwork display from the `metadata` role.

The `metadata` role now only handles text information (title, artist, album, etc.), while `artwork` handles all image display.

Additionally, as discussed on [discord](https://discord.com/channels/753947050995089438/1369735163629801532/1421197479566643333):
- The `stream/request-format` message is extended to support both `player` and `artwork` roles, allowing artwork clients to dynamically adapt image formats and resolutions.
- We now assume that the server supports all image formats

Empty binary messages are now defined to clear artwork image.

This PR also implements another Idea, artwork channels:
- Artwork clients can support 1-4 independent channels, allowing simultaneous display of multiple images (e.g., album art on one channel, artist photos on another). Each channel can specify its source type (`album` or `artist`), format (`jpeg`, `png`, `bmp`), and resolution.
- This also allows client use cases such as showing a smaller thumbnail image while a full screen player is minimized. Without having to downscale the image themselves.
- Binary message types are updated: types 2-5 for artwork channels 0-3, type 6 for visualizer (previously type 3). A later PR will properly clean up binary message types by grouping them by role.