### PR TITLE
Move `playback_state` to `group/update`

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ State update of the group this client is part of.
 
 Delta updates that must be merged into existing state. Fields set to `null` should be nullified.
 
-- `playback_state?`: 'playing' | 'paused' | 'stopped' - only sent to clients with `controller` or `metadata` roles
+- `playback_state?`: 'playing' | 'paused' | 'stopped' - playback state of the group
 - `group_id?`: string - group identifier
 - `group_name?`: string - friendly name of the group
 - `controller?`: object - only sent to clients with `controller` role ([see controller object details](#server--client-groupupdate-controller-object))


### PR DESCRIPTION
Since `group/update` is now a core message, we can move `playback_state` to it.
Also I don't think the added complexity from limiting `playback_state` to just the `controller` and `metadata` roles is enough to justify the very slight message size increase for other roles.