### PR TITLE
Replace `role` specific messages with 4 core messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ For synchronization, all timing is relative to the server's monotonic clock. The
 
 Client sends state updates to the server. Contains role-specific state objects based on the client's supported roles.
 
-Must be sent immediately after receiving [`server/hello`](#server--client-serverhello) (for roles that require initial state) and whenever any state changes.
+Must be sent immediately after receiving [`server/hello`](#server--client-serverhello) and whenever any state changes, including when the volume was changed through a `server/command` received from the server or when the volume was adjusted locally.
 
 Only include fields that have changed. The server will merge these updates into existing state.
 


### PR DESCRIPTION
This PR refactors the specification to introduce 4 new core messages:
- `client/update`
- `server/update`
- `client/command`
- `server/command`

These replace existing messages such as:
  - `player/update` → `client/state` (with player object)
  - `group/command` → `client/command` (with controller object)
  - `group/switch` → `client/command` (with controller 'switch' command)
  - `player/command` → `server/command` (with player object)
  - `session/update` → `server/state` (with metadata object)
  - `group/update` (only controller object) → `server/state` (with controller object)

  This consolidation simplifies the protocol by reducing the number of message types while maintaining clear separation between state updates and commands. Role-specific data is now organized as objects within
  these universal core messages.