### PR TITLE
Fix spec wording and consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ WebSocket text messages are used to send JSON payloads.
 
 **Note:** In field definitions, `?` indicates an optional field (e.g., `field?`: type means the field may be omitted).
 
+All messages have a `type` field identifying the message and a `payload` object containing message-specific data. The payload structure varies by message type and is detailed in each message section below.
+
 Message format example:
 
 ```json


### PR DESCRIPTION
Fixes several issues in the protocol specification wording and improves consistency across message documentation. (Almost) no protocol changes, only documentation improvements.

Protocol changes:
- Added missing optional markers (`?`) to `stream/update` player object fields
- Added missing `'none'` option in `stream/update` artwork source field
- Changed `client/state` to require all fields in initial message (not just deltas)

Documentation improvements:
- Consistent terminology for null handling ("cleared from" vs "nullified")
- Removed redundant sender/receiver phrases
- Added explicit merge instructions for delta updates
- Documented behavior for late-arriving audio chunks
- Clarified initial vs subsequent state updates
- Improve example and explain JSON message format