### PR TITLE
Clarify error state reporting when sync cannot be maintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Binary audio messages contain timestamps in the server's time domain indicating 
 
 - Each client is responsible for maintaining synchronization with the server's timestamps
 - Clients maintain accurate sync by adding or removing samples using interpolation to compensate for clock drift
-- When a client cannot maintain sync (e.g., buffer underrun), it should mute its audio output and continue buffering until it can resume synchronized playback
+- When a client cannot maintain sync (e.g., buffer underrun), it should send the 'error' state via [`client/state`](#client--server-clientstate-player-object), mute its audio output, and continue buffering until it can resume synchronized playback, at which point it should send the 'synchronized' state
 - The server is unaware of individual client synchronization accuracy - it simply broadcasts timestamped audio
 - The server sends audio to late-joining clients with future timestamps only, allowing them to buffer and start playback in sync with existing clients
 - Audio chunks may arrive with timestamps in the past due to network delays or buffering; clients should drop these late chunks to maintain sync


### PR DESCRIPTION
Explicitly require clients to notify the server when they cannot maintain sync (e.g., buffer underrun) by sending 'error' state via client/state before muting and rebuffering, then send 'synchronized' state when resuming playback.