### PR TITLE
Define how group volume is calculated and applied

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,6 +419,8 @@ Control the group that's playing and switch groups. Only valid from clients with
   - `volume?`: integer - volume range 0-100, only set if `command` is `volume`
   - `mute?`: boolean - true to mute, false to unmute, only set if `command` is `mute`
 
+**Setting group volume:** When setting group volume via the 'volume' command, the server calculates the difference from the current group volume and applies that delta to each player's volume, preserving relative volume levels between players.
+
 **Note:** When `command` is 'switch', the server moves this client to the next group in a predefined cycle:
 
 For clients **with** the `player` role, the cycle includes:
@@ -439,7 +441,7 @@ The `controller` object in [`server/state`](#server--client-serverstate) has thi
   - `volume`: integer - volume of the whole group, range 0-100
   - `muted`: boolean - mute state of the whole group
 
-**Note:** Group volume is calculated as the average of all player volumes in the group. When setting group volume via the 'volume' command, the server calculates the difference from the current group volume and applies that delta to each player's volume, preserving relative volume levels between players.
+**Reading group volume:** Group volume is calculated as the average of all player volumes in the group.
 
 
 ## Metadata messages

--- a/README.md
+++ b/README.md
@@ -439,6 +439,8 @@ The `controller` object in [`server/state`](#server--client-serverstate) has thi
   - `volume`: integer - volume of the whole group, range 0-100
   - `muted`: boolean - mute state of the whole group
 
+**Note:** Group volume is calculated as the average of all player volumes in the group. When setting group volume via the 'volume' command, the server calculates the difference from the current group volume and applies that delta to each player's volume, preserving relative volume levels between players.
+
 
 ## Metadata messages
 This section describes messages specific to clients with the `metadata` role, which handle display of track information and playback progress. Metadata clients receive state updates with track details.

--- a/README.md
+++ b/README.md
@@ -419,7 +419,19 @@ Control the group that's playing and switch groups. Only valid from clients with
   - `volume?`: integer - volume range 0-100, only set if `command` is `volume`
   - `mute?`: boolean - true to mute, false to unmute, only set if `command` is `mute`
 
-**Setting group volume:** When setting group volume via the 'volume' command, the server calculates the difference from the current group volume and applies that delta to each player's volume, preserving relative volume levels between players.
+**Setting group volume:** When setting group volume via the 'volume' command, the server applies the following algorithm to preserve relative volume levels while achieving the requested volume as closely as player boundaries allow:
+
+1. Calculate the delta: `delta = requested_volume - current_group_volume` (where current group volume is the average of all player volumes)
+2. Apply the delta to each player's volume
+3. Clamp any player volumes that exceed boundaries (0-100%)
+4. If any players were clamped:
+   - Calculate the lost delta: `sum of (proposed_volume - clamped_volume)` for all clamped players
+   - Divide the lost delta equally among non-clamped players
+   - Repeat steps 1-4 until either:
+     - All delta has been successfully applied, or
+     - All players are clamped at their volume boundaries
+
+This ensures that when setting group volume to 100%, all players will reach 100% if possible, and the final group volume matches the requested volume as closely as player boundaries allow.
 
 **Note:** When `command` is 'switch', the server moves this client to the next group in a predefined cycle:
 


### PR DESCRIPTION
Define group volume as the average of all player volumes. When setting group volume, apply the delta to each player to preserve relative volume levels between players.