### PR TITLE
Future proof protocol with role versioning and support for custom roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,10 +141,12 @@ WebSocket binary messages are used to send audio chunks, media art, and visualiz
 Binary message IDs organize bits into fields: **bits 7-2** identify the role type, **bits 1-0** identify the message slot within that role. This allocates 4 message slots per role.
 
 **Role assignments:**
-- `000000xx` (0-3): Player role
-- `000001xx` (4-7): Artwork role
-- `000010xx` (8-11): Visualizer role
-- Roles 3-47 (IDs 12-191): Reserved for future roles
+- `000000xx` (0-3): Reserved for future use
+- `000001xx` (4-7): Player role
+- `000010xx` (8-11): Artwork role
+- `000011xx` (12-15): Reserved for a future role
+- `00010xxx` (16-23): Visualizer role
+- Roles 6-47 (IDs 24-191): Reserved for future roles
 - Roles 48-63 (IDs 192-255): Available for use by [application-specific roles](#application-specific-roles)
 
 **Message slots within each role:**
@@ -153,7 +155,7 @@ Binary message IDs organize bits into fields: **bits 7-2** identify the role typ
 - Slot 2: `xxxxxx10`
 - Slot 3: `xxxxxx11`
 
-**Note:** Role versions share the same binary message IDs (e.g., `player@v1` and `player@v2` both use IDs 0-3).
+**Note:** Role versions share the same binary message IDs (e.g., `player@v1` and `player@v2` both use IDs 4-7).
 
 ## Clock Synchronization
 
@@ -202,13 +204,13 @@ sequenceDiagram
 
     loop During playback
         alt Player role
-            Server->>Client: binary Type 0 (audio chunks with timestamps)
+            Server->>Client: binary Type 4 (audio chunks with timestamps)
         end
         alt Artwork role
-            Server->>Client: binary Types 4-7 (artwork channels 0-3)
+            Server->>Client: binary Types 8-11 (artwork channels 0-3)
         end
         alt Visualizer role
-            Server->>Client: binary Type 8 (visualization data)
+            Server->>Client: binary Type 16 (visualization data)
         end
     end
 
@@ -485,7 +487,7 @@ When [`stream/clear`](#server--client-streamclear) includes the player role, cli
 
 Binary messages should be rejected if there is no active stream.
 
-- Byte 0: message type `0` (uint8)
+- Byte 0: message type `4` (uint8)
 - Bytes 1-8: timestamp (big-endian int64) - server clock time in microseconds when the first sample should be output
 - Rest of bytes: encoded audio frame
 
@@ -651,15 +653,15 @@ The `artwork` object in [`stream/start`](#server--client-streamstart) has this s
 
 Binary messages should be rejected if there is no active stream.
 
-- Byte 0: message type `4`-`7` (uint8) - corresponds to artwork channel 0-3 respectively
+- Byte 0: message type `8`-`11` (uint8) - corresponds to artwork channel 0-3 respectively
 - Bytes 1-8: timestamp (big-endian int64) - server clock time in microseconds when the image should be displayed by the device
 - Rest of bytes: encoded image
 
 The message type determines which artwork channel this image is for:
-- Type `4`: Channel 0 (Artwork role, slot 0)
-- Type `5`: Channel 1 (Artwork role, slot 1)
-- Type `6`: Channel 2 (Artwork role, slot 2)
-- Type `7`: Channel 3 (Artwork role, slot 3)
+- Type `8`: Channel 0 (Artwork role, slot 0)
+- Type `9`: Channel 1 (Artwork role, slot 1)
+- Type `10`: Channel 2 (Artwork role, slot 2)
+- Type `11`: Channel 3 (Artwork role, slot 3)
 
 The timestamp indicates when this artwork should be displayed. Clients must translate this server timestamp to their local clock using the offset computed from clock synchronization.
 
@@ -691,7 +693,7 @@ When [`stream/clear`](#server--client-streamclear) includes the visualizer role,
 
 Binary messages should be rejected if there is no active stream.
 
-- Byte 0: message type `8` (uint8)
+- Byte 0: message type `16` (uint8)
 - Bytes 1-8: timestamp (big-endian int64) - server clock time in microseconds when the visualization should be displayed by the device
 - Rest of bytes: visualization data
 

--- a/README.md
+++ b/README.md
@@ -388,6 +388,8 @@ Ends the stream for one or more roles. When received, clients should stop output
 
 - `roles?`: string[] - roles to end streams for ('player', 'artwork', 'visualizer'). If omitted, ends all active streams
 
+[Application-specific roles](#application-specific-roles) may also be included in this array (names starting with `_`).
+
 ### Server → Client: `group/update`
 
 State update of the group this client is part of.

--- a/README.md
+++ b/README.md
@@ -630,7 +630,7 @@ Request the server to change the artwork format for a specific channel. The clie
 After receiving this message, the server responds with [`stream/start`](#server--client-streamstart) for the artwork role with the new format, followed by immediate artwork updates through binary messages.
 
 - `artwork`: object
-  - `channel`: integer - channel number (0-3) corresponding to the channel index declared in the artwork [`client/hello`](#client--server-clienthello-artwork-support-object)
+  - `channel`: integer - channel number (0-3) corresponding to the channel index declared in the artwork [`client/hello`](#client--server-clienthello-artworkv1-support-object)
   - `source?`: 'album' | 'artist' | 'none' - artwork source type
   - `format?`: 'jpeg' | 'png' | 'bmp' - requested image format identifier
   - `media_width?`: integer - requested max width in pixels

--- a/README.md
+++ b/README.md
@@ -265,9 +265,9 @@ Players that can output audio should have the role `player`.
   - `metadata@v1` - displays text metadata describing the currently playing audio
   - `artwork@v1` - displays artwork images
   - `visualizer@v1` - visualizes audio
-- `player@v1_support?`: object - only if `player@v1` is listed ([see player support object details](#client--server-clienthello-player-support-object))
-- `artwork@v1_support?`: object - only if `artwork@v1` is listed ([see artwork support object details](#client--server-clienthello-artwork-support-object))
-- `visualizer@v1_support?`: object - only if `visualizer@v1` is listed ([see visualizer support object details](#client--server-clienthello-visualizer-support-object))
+- `player@v1_support?`: object - only if `player@v1` is listed ([see player@v1 support object details](#client--server-clienthello-playerv1-support-object))
+- `artwork@v1_support?`: object - only if `artwork@v1` is listed ([see artwork@v1 support object details](#client--server-clienthello-artworkv1-support-object))
+- `visualizer@v1_support?`: object - only if `visualizer@v1` is listed ([see visualizer@v1 support object details](#client--server-clienthello-visualizerv1-support-object))
 
 **Note:** Each role version may have its own support object (e.g., `player@v1_support`, `player@v2_support`). Application-specific roles or role versions follow the same pattern (e.g., `_myapp_display@v1_support`, `player@_experimental_support`).
 
@@ -413,11 +413,11 @@ Upon receiving this message, the server should initiate the disconnect.
 ## Player messages
 This section describes messages specific to clients with the `player` role, which handle audio output and synchronized playback. Player clients receive timestamped audio data, manage their own volume and mute state, and can request different audio formats based on their capabilities and current conditions.
 
-### Client → Server: `client/hello` player support object
+### Client → Server: `client/hello` player@v1 support object
 
-The `player_support` object in [`client/hello`](#client--server-clienthello) has this structure:
+The `player@v1_support` object in [`client/hello`](#client--server-clienthello) has this structure:
 
-- `player_support`: object
+- `player@v1_support`: object
   - `supported_formats`: object[] - list of supported audio formats in priority order (first is preferred)
     - `codec`: 'opus' | 'flac' | 'pcm' - codec identifier
     - `channels`: integer - supported number of channels (e.g., 1 = mono, 2 = stereo)
@@ -438,8 +438,8 @@ State updates must be sent whenever any state changes, including when the volume
 
 - `player`: object
   - `state`: 'synchronized' | 'error' - state of the player, should always be `synchronized` unless there is an error preventing current or future playback (unable to keep up, issues keeping the clock in sync, etc)
-  - `volume?`: integer - range 0-100, must be included if 'volume' is in `supported_commands` from [`player_support`](#client--server-clienthello-player-support-object)
-  - `muted?`: boolean - mute state, must be included if 'mute' is in `supported_commands` from [`player_support`](#client--server-clienthello-player-support-object)
+  - `volume?`: integer - range 0-100, must be included if 'volume' is in `supported_commands` from [`player@v1_support`](#client--server-clienthello-playerv1-support-object)
+  - `muted?`: boolean - mute state, must be included if 'mute' is in `supported_commands` from [`player@v1_support`](#client--server-clienthello-playerv1-support-object)
 
 ### Client → Server: `stream/request-format` player object
 
@@ -462,7 +462,7 @@ The `player` object in [`server/command`](#server--client-servercommand) has thi
 Request the player to perform an action, e.g., change volume or mute state.
 
 - `player`: object
-  - `command`: 'volume' | 'mute' - should be one of the values listed in `supported_commands` in the [`player_support`](#client--server-clienthello-player-support-object) object in the [`client/hello`](#client--server-clienthello) message. Commands not in `supported_commands` are ignored by the client
+  - `command`: 'volume' | 'mute' - should be one of the values listed in `supported_commands` in the [`player@v1_support`](#client--server-clienthello-playerv1-support-object) object in the [`client/hello`](#client--server-clienthello) message. Commands not in `supported_commands` are ignored by the client
   - `volume?`: integer - volume range 0-100, only set if `command` is `volume`
   - `mute?`: boolean - true to mute, false to unmute, only set if `command` is `mute`
 
@@ -592,11 +592,11 @@ This section describes messages specific to clients with the `artwork` role, whi
 
 **Channels:** Artwork clients can support 1-4 independent channels, allowing them to display multiple related images. For example, a device could display album artwork on one channel while simultaneously showing artist photos or background images on other channels. Each channel operates independently with its own format, resolution, and source type (album or artist artwork).
 
-### Client → Server: `client/hello` artwork support object
+### Client → Server: `client/hello` artwork@v1 support object
 
-The `artwork_support` object in [`client/hello`](#client--server-clienthello) has this structure:
+The `artwork@v1_support` object in [`client/hello`](#client--server-clienthello) has this structure:
 
-- `artwork_support`: object
+- `artwork@v1_support`: object
   - `channels`: object[] - list of supported artwork channels (length 1-4), array index is the channel number
     - `source`: 'album' | 'artist' | 'none' - artwork source type
     - `format`: 'jpeg' | 'png' | 'bmp' - image format identifier
@@ -667,11 +667,11 @@ The timestamp indicates when this artwork should be displayed. Clients must tran
 ## Visualizer messages
 This section describes messages specific to clients with the `visualizer` role, which create visual representations of the audio being played. Visualizer clients receive audio analysis data like FFT information that corresponds to the current audio timeline.
 
-### Client → Server: `client/hello` visualizer support object
+### Client → Server: `client/hello` visualizer@v1 support object
 
-The `visualizer_support` object in [`client/hello`](#client--server-clienthello) has this structure:
+The `visualizer@v1_support` object in [`client/hello`](#client--server-clienthello) has this structure:
 
-- `visualizer_support`: object
+- `visualizer@v1_support`: object
   - Desired FFT details (to be determined)
   - `buffer_capacity`: integer - max size in bytes of visualization data messages in the buffer that are yet to be displayed
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ WebSocket binary messages are used to send audio chunks, media art, and visualiz
 
 ### Binary Message ID Structure
 
-Binary message IDs organize bits into fields: **bits 7-2** identify the role type, **bits 1-0** identify the message slot within that role. This allocates 4 message slots per role.
+Binary message IDs typically use **bits 7-2** for role type and **bits 1-0** for message slot, allocating 4 IDs per role. Roles with expanded allocations use **bits 2-0** for message slot (8 IDs).
 
 **Role assignments:**
 - `000000xx` (0-3): Reserved for future use
@@ -149,11 +149,13 @@ Binary message IDs organize bits into fields: **bits 7-2** identify the role typ
 - Roles 6-47 (IDs 24-191): Reserved for future roles
 - Roles 48-63 (IDs 192-255): Available for use by [application-specific roles](#application-specific-roles)
 
-**Message slots within each role:**
+**Message slots:**
 - Slot 0: `xxxxxx00`
 - Slot 1: `xxxxxx01`
 - Slot 2: `xxxxxx10`
 - Slot 3: `xxxxxx11`
+
+Roles with expanded allocations have slots 0-7.
 
 **Note:** Role versions share the same binary message IDs (e.g., `player@v1` and `player@v2` both use IDs 4-7).
 

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ Only after receiving this message should the client send any other messages (inc
   - `discovery` - server is connecting for general availability (e.g., initial discovery, reconnection after connection loss)
   - `playback` - server needs client for active or upcoming playback
 
-**Note:** Clients can assume that the server is up-to-date, meaning `active_roles` will equal their `supported_roles`.
+**Note:** Servers will always activate the client's [preferred](#priority-and-activation) version of each role. Checking `active_roles` is only necessary to detect outdated servers or confirm activation of [application-specific roles](#application-specific-roles).
 
 ### Server → Client: `server/time`
 


### PR DESCRIPTION
Introduces explicit versioning for roles using the @ character (e.g., player@v1, controller@v1). Clients list roles in supported_roles in priority order, and the server activates one version per role family (the first match it implements). The server reports which versions it activated in the active_roles field.

Application-specific roles and versions use the _ prefix.

Clients can optionally implement fallback support by listing multiple versions (e.g., ["player@v2", "player@v1"]) to support older servers, but this is not required, since servers can detect when they need to be updated by tracking client requests for unimplemented roles or versions.

The core message format version field is now explicitly fixed at 1 and is independent of role versions.

Minimal overhead for clients: just use versioned role names in supported_roles and versioned support object keys. No other changes required.