### PR TITLE
Add multi-server support through `client/goodbye` message

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,25 @@ The server discovers available clients through mDNS and connects to each client 
 
 **Note:** Do not manually connect to servers if you are advertising `_resonate._tcp`.
 
+#### Multiple Servers
+
+In environments with multiple Resonate servers, servers may need to reconnect to clients when starting playback to reclaim them. The [`server/hello`](#server--client-serverhello) message includes a `connection_reason` field indicating whether the server is connecting for general availability (`'discovery'`) or for active/upcoming playback (`'playback'`).
+
+Clients can only be connected to one server at a time. Clients must persistently store the `server_id` of the server that most recently had `playback_state: 'playing'` (the "last played server").
+
+When a second server connects, clients must:
+
+1. **Accept incoming connections**: Complete the handshake (send [`client/hello`](#client--server-clienthello), receive [`server/hello`](#server--client-serverhello)) with the new server before making any decisions.
+
+2. **Decide which server to keep**:
+   - If the new server's `connection_reason` is `'playback'` → switch to new server
+   - If the new server's `connection_reason` is `'discovery'` and the existing server connected with `'playback'` → keep existing server
+   - If both servers have `connection_reason: 'discovery'`:
+     - Prefer the server matching the stored last played server
+     - If neither matches (or no history), keep the existing server
+
+3. **Disconnect**: Send [`client/goodbye`](#client--server-clientgoodbye) with reason `'another_server'` to the server being disconnected, then close the connection.
+
 ### Client Initiated Connections
 
 If clients prefer to initiate the connection instead of waiting for the server to connect, the server must be discoverable via mDNS using:
@@ -43,6 +62,10 @@ If clients prefer to initiate the connection instead of waiting for the server t
 Clients discover the server through mDNS and initiate a WebSocket connection using the advertised address and path.
 
 **Note:** Do not advertise `_resonate._tcp` if the client plans to initiate the connection.
+
+#### Multiple Servers
+
+Unlike server-initiated connections, servers cannot reclaim clients by reconnecting. How clients handle multiple discovered servers, server selection, and switching is implementation-defined.
 
 **Note:** After this point, Resonate works independently of how the connection was established. The Resonate client is always the consumer of data like audio or metadata, regardless of who initiated the connection.
 
@@ -129,7 +152,7 @@ sequenceDiagram
     Note over Client,Server: Text messages = JSON payloads, Binary messages = Audio/Art/Visualization
 
     Client->>Server: client/hello (roles and capabilities)
-    Server->>Client: server/hello (server info)
+    Server->>Client: server/hello (server info, connection_reason)
 
     alt Player role
         Client->>Server: client/state (player: volume, muted, state)
@@ -180,6 +203,11 @@ sequenceDiagram
     alt Player role
         Client->>Server: client/state (player idle state)
     end
+
+    alt Graceful disconnect
+        Client->>Server: client/goodbye (reason)
+        Note over Client,Server: Server initiates disconnect
+    end
 ```
 
 ## Core messages
@@ -227,6 +255,9 @@ Only after receiving this message should the client send any other messages (inc
 - `server_id`: string - identifier of the server
 - `name`: string - friendly name of the server
 - `version`: integer - latest supported version of Resonate
+- `connection_reason`: 'discovery' | 'playback' - only relevant for [server-initiated connections](#multiple-servers)
+  - `discovery` - server is connecting for general availability (e.g., initial discovery, reconnection after connection loss)
+  - `playback` - server needs client for active or upcoming playback
 
 ### Server → Client: `server/time`
 
@@ -316,6 +347,19 @@ Contains delta updates with only the changed fields. The client should merge the
 - `group_id?`: string - group identifier
 - `group_name?`: string - friendly name of the group
 
+### Client → Server: `client/goodbye`
+
+Sent by the client before gracefully closing the connection. This allows the client to inform the server why it is disconnecting.
+
+Upon receiving this message, the server should initiate the disconnect.
+
+- `reason`: 'another_server' | 'shutdown' | 'restart' | 'user_request'
+  - `another_server` - client is switching to a different Resonate server. Server should not auto-reconnect but should show the client as available for future playback
+  - `shutdown` - client is shutting down. Server should not auto-reconnect
+  - `restart` - client is restarting and will reconnect. Server should auto-reconnect
+  - `user_request` - user explicitly requested to disconnect from this server. Server should not auto-reconnect
+
+**Note:** Clients may close the connection without sending this message (e.g., crash, network loss), or immediately after sending `client/goodbye` without waiting for the server to disconnect.
 
 ## Player messages
 This section describes messages specific to clients with the `player` role, which handle audio output and synchronized playback. Player clients receive timestamped audio data, manage their own volume and mute state, and can request different audio formats based on their capabilities and current conditions.

--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ Upon receiving this message, the server should initiate the disconnect.
   - `restart` - client is restarting and will reconnect. Server should auto-reconnect
   - `user_request` - user explicitly requested to disconnect from this server. Server should not auto-reconnect
 
-**Note:** Clients may close the connection without sending this message (e.g., crash, network loss), or immediately after sending `client/goodbye` without waiting for the server to disconnect.
+**Note:** Clients may close the connection without sending this message (e.g., crash, network loss), or immediately after sending `client/goodbye` without waiting for the server to disconnect. When a client disconnects without sending `client/goodbye`, servers should assume the disconnect reason is `restart` and attempt to auto-reconnect.
 
 ## Player messages
 This section describes messages specific to clients with the `player` role, which handle audio output and synchronized playback. Player clients receive timestamped audio data, manage their own volume and mute state, and can request different audio formats based on their capabilities and current conditions.


### PR DESCRIPTION
Enables clients to switch between servers in multi-server environments.

Servers now indicate their connection intent via `connection_reason` in `server/hello`, allowing clients to decide which server to keep when a second one connects. The new `client/goodbye` message lets clients explain why they're disconnecting, helping servers respond appropriately.

For client-initiated connections, multi-server behavior is left implementation-defined since servers cannot reclaim clients.