### PR TITLE
Role-specific stream lifecycles

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,14 +347,6 @@ Contains delta updates with only the changed fields. The client should merge the
 - `group_id?`: string - group identifier
 - `group_name?`: string - friendly name of the group
 
-#### Playback State
-
-- **`playing`**: Audio is playing.
-- **`paused`**: Audio is not playing. Can be resumed.
-- **`stopped`**: Audio is not playing. Nothing is loaded. No active streams.
-
-**Note:** Servers must keep `playback_state` accurate. Controllers can use this state to determine [which controls to display](#playback-controls).
-
 ### Client → Server: `client/goodbye`
 
 Sent by the client before gracefully closing the connection. This allows the client to inform the server why it is disconnecting.
@@ -501,14 +493,6 @@ The `controller` object in [`server/state`](#server--client-serverstate) has thi
   - `muted`: boolean - mute state of the whole group
 
 **Reading group volume:** Group volume is calculated as the average of all player volumes in the group.
-
-### Playback Controls
-
-Controller UIs should display controls based on the current [`playback_state`](#playback-state) and `supported_commands`:
-
-- **`playing`**: Show pause button (send `pause` command) if `pause` is in `supported_commands`
-- **`paused`**: Show play button (send `play` command) if `play` is in `supported_commands`
-- **`stopped`**: Show play button (send `play` command) if `play` is in `supported_commands`
 
 ## Metadata messages
 This section describes messages specific to clients with the `metadata` role, which handle display of track information and playback progress. Metadata clients receive state updates with track details.

--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ Contains delta updates with only the changed fields. The client should merge the
 - **`paused`**: Audio is not playing. Can be resumed.
 - **`stopped`**: Audio is not playing. Nothing is loaded. No active streams.
 
-**Note:** Servers must keep `playback_state` accurate at all times. Clients can rely on this state to determine playback behavior.
+**Note:** Servers must keep `playback_state` accurate at all times. Clients can rely on this state to determine playback behavior and [which controls to display](#playback-controls).
 
 ### Client → Server: `client/goodbye`
 
@@ -502,6 +502,13 @@ The `controller` object in [`server/state`](#server--client-serverstate) has thi
 
 **Reading group volume:** Group volume is calculated as the average of all player volumes in the group.
 
+### Playback Controls
+
+Controller UIs should display controls based on the current [`playback_state`](#playback-state) and `supported_commands`:
+
+- **`playing`**: Show pause button (send `pause` command) if `pause` is in `supported_commands`
+- **`paused`**: Show play button (send `play` command) if `play` is in `supported_commands`
+- **`stopped`**: Show play button (send `play` command) if `play` is in `supported_commands`
 
 ## Metadata messages
 This section describes messages specific to clients with the `metadata` role, which handle display of track information and playback progress. Metadata clients receive state updates with track details.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Resonate is a multi-room music experience protocol. The goal of the protocol is 
   - **Artwork** - displays artwork images. Has preferred format for images
   - **Visualizer** - visualizes music. Has preferred format for audio features
 - **Resonate Group** - a group of clients. Each client belongs to exactly one group, and every group has at least one client. Every group has a unique identifier. Each group has the following states: list of member clients, volume, mute, and playback state
-- **Resonate Stream** - client-specific details on how the server is formatting and sending binary data. Each client receives its own independently encoded stream based on its capabilities and preferences. For players, the server sends audio chunks as far ahead as the client's buffer capacity allows. For artwork clients, the server sends album artwork and other visual images through the stream
+- **Resonate Stream** - client-specific details on how the server is formatting and sending binary data. Each role (player, artwork, visualizer) has an independent stream lifecycle. Each client receives its own independently encoded stream based on its capabilities and preferences. For players, the server sends audio chunks as far ahead as the client's buffer capacity allows. For artwork clients, the server sends album artwork and other visual images through the stream
 
 ## Establishing a Connection
 
@@ -349,6 +349,16 @@ Contains delta updates with only the changed fields. The client should merge the
 - `playback_state?`: 'playing' | 'paused' | 'stopped' - playback state of the group
 - `group_id?`: string - group identifier
 - `group_name?`: string - friendly name of the group
+
+#### Playback State and Stream Lifecycle
+
+The `playback_state` and stream lifecycle are independent concepts:
+
+- **`playing`**: Audio/visualization data is being sent. Streams remain active.
+- **`paused`**: No new audio/visualization data is sent, but streams remain active. Artwork continues to display. Metadata is retained.
+- **`stopped`**: Server sends `stream/end` (all roles). All buffers cleared, metadata/artwork cleared.
+
+Pausing does NOT require `stream/end`. The server simply stops sending binary data while keeping streams open. This allows artwork to remain visible and metadata to stay populated during pause.
 
 ### Client → Server: `client/goodbye`
 

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ sequenceDiagram
     end
 
     alt Seek operation
-        Server->>Client: stream/flush (roles: [player, visualizer])
+        Server->>Client: stream/clear (roles: [player, visualizer])
     end
 
     alt Controller role
@@ -314,11 +314,11 @@ Starts a stream for one or more roles. If sent for a role that already has an ac
 - `artwork?`: object - only sent to clients with the `artwork` role ([see artwork object details](#server--client-streamstart-artwork-object))
 - `visualizer?`: object - only sent to clients with the `visualizer` role ([see visualizer object details](#server--client-streamstart-visualizer-object))
 
-### Server → Client: `stream/flush`
+### Server → Client: `stream/clear`
 
 Instructs clients to clear buffers without ending the stream. Used for seek operations.
 
-- `roles?`: string[] - which roles to flush: '[player](#server--client-streamflush-player)', '[visualizer](#server--client-streamflush-visualizer)', or both. If omitted, flushes both roles
+- `roles?`: string[] - which roles to clear: '[player](#server--client-streamclear-player)', '[visualizer](#server--client-streamclear-visualizer)', or both. If omitted, clears both roles
 
 ### Client → Server: `stream/request-format`
 
@@ -436,9 +436,9 @@ The `player` object in [`stream/start`](#server--client-streamstart) has this st
   - `bit_depth`: integer - bit depth to be used
   - `codec_header?`: string - Base64 encoded codec header (if necessary; e.g., FLAC)
 
-### Server → Client: `stream/flush` player
+### Server → Client: `stream/clear` player
 
-When [`stream/flush`](#server--client-streamflush) includes the player role, clients should clear all buffered audio chunks and continue with chunks received after this message.
+When [`stream/clear`](#server--client-streamclear) includes the player role, clients should clear all buffered audio chunks and continue with chunks received after this message.
 
 ### Server → Client: Audio Chunks (Binary)
 
@@ -623,9 +623,9 @@ The `visualizer` object in [`stream/start`](#server--client-streamstart) has thi
 - `visualizer`: object
   - FFT details (to be determined)
 
-### Server → Client: `stream/flush` visualizer
+### Server → Client: `stream/clear` visualizer
 
-When [`stream/flush`](#server--client-streamflush) includes the visualizer role, clients should clear all buffered visualization data and continue with data received after this message.
+When [`stream/clear`](#server--client-streamclear) includes the visualizer role, clients should clear all buffered visualization data and continue with data received after this message.
 
 ### Server → Client: Visualization Data (Binary)
 

--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ Contains delta updates with only the changed fields. The client should merge the
 - **`paused`**: Audio is not playing. Can be resumed.
 - **`stopped`**: Audio is not playing. Nothing is loaded. No active streams.
 
-**Note:** Servers must keep `playback_state` accurate at all times. Clients can rely on this state to determine playback behavior and [which controls to display](#playback-controls).
+**Note:** Servers must keep `playback_state` accurate. Controllers can use this state to determine [which controls to display](#playback-controls).
 
 ### Client → Server: `client/goodbye`
 


### PR DESCRIPTION
Previously, streams were tied to playback state, requiring artwork to be discarded when pausing or seeking. This PR decouples stream lifecycles per role, so artwork can persist during pause while audio streams are managed independently.

Removes `stream/update` - format changes now use `stream/start` directly since it updates configuration without clearing buffers if the stream is already active. Adds `stream/clear` for seek operations to clear buffers without ending streams.