### PR TITLE
Add external audio source support

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Binary audio messages contain timestamps in the server's time domain indicating 
 
 - Each client is responsible for maintaining synchronization with the server's timestamps
 - Clients maintain accurate sync by adding or removing samples using interpolation to compensate for clock drift
-- When a client cannot maintain sync (e.g., buffer underrun), it should send the 'error' state via [`client/state`](#client--server-clientstate-player-object), mute its audio output, and continue buffering until it can resume synchronized playback, at which point it should send the 'synchronized' state
+- When a client cannot maintain sync (e.g., buffer underrun), it should send `state: 'error'` via [`client/state`](#client--server-clientstate), mute its audio output, and continue buffering until it can resume synchronized playback, at which point it should send `state: 'synchronized'`
 - The server is unaware of individual client synchronization accuracy - it simply broadcasts timestamped audio
 - The server sends audio to late-joining clients with future timestamps only, allowing them to buffer and start playback in sync with existing clients
 - Audio chunks may arrive with timestamps in the past due to network delays or buffering; clients should drop these late chunks to maintain sync
@@ -188,8 +188,9 @@ sequenceDiagram
     Client->>Server: client/hello (roles and capabilities)
     Server->>Client: server/hello (server info, connection_reason)
 
+    Client->>Server: client/state (state: synchronized)
     alt Player role
-        Client->>Server: client/state (player: volume, muted, state)
+        Client->>Server: client/state (player: volume, muted)
     end
 
     loop Continuous clock sync
@@ -229,8 +230,8 @@ sequenceDiagram
         Client->>Server: client/command (controller: play/pause/volume/switch/etc)
     end
 
-    alt Player role state changes
-        Client->>Server: client/state (player state changes)
+    alt State changes
+        Client->>Server: client/state (state and/or player changes)
     end
 
     alt Server commands player
@@ -238,9 +239,6 @@ sequenceDiagram
     end
 
     Server->>Client: stream/end (ends all role streams)
-    alt Player role
-        Client->>Server: client/state (player idle state)
-    end
 
     alt Graceful disconnect
         Client->>Server: client/goodbye (reason)
@@ -314,15 +312,30 @@ For synchronization, all timing is relative to the server's monotonic clock. The
 
 ### Client → Server: `client/state`
 
-Client sends state updates to the server. Contains role-specific state objects based on the client's supported roles.
+Client sends state updates to the server. Contains client-level state and role-specific state objects.
 
-Must be sent immediately after receiving [`server/hello`](#server--client-serverhello) for roles that report state (such as `player`), and whenever any state changes thereafter.
+Must be sent immediately after receiving [`server/hello`](#server--client-serverhello), and whenever any state changes thereafter.
 
 For the initial message, include all state fields. For subsequent updates, only include fields that have changed. The server will merge these updates into existing state.
 
+- `state`: 'synchronized' | 'error' | 'external_source' - operational state of the client
+  - `'synchronized'` - client is operational and synchronized with server timestamps
+  - `'error'` - client has a problem preventing normal operation (unable to keep up, clock sync issues, etc.)
+  - `'external_source'` - client is in use by an external system and cannot participate in Sendspin playback. See [External Source Handling](#external-source-handling)
 - `player?`: object - only if client has `player` role ([see player state object details](#client--server-clientstate-player-object))
 
 [Application-specific roles](#application-specific-roles) may also include objects in this message (keys starting with `_`).
+
+### External Source Handling
+
+When a client sets `state: 'external_source'`, it indicates the client's output is in use by an external system (e.g., a different audio source, HDMI input, or local media playback) and cannot participate in Sendspin playback.
+
+#### Server behavior when `state` changes to `'external_source'`:
+
+1. Remember the client's current group as its "previous group" (see [switch command cycle](#switch-command-cycle))
+2. Move the client to a new solo group (stopped)
+   - Send [`group/update`](#server--client-groupupdate) with the new group information
+   - Send [`stream/end`](#server--client-streamend) for all active streams
 
 ### Client → Server: `client/command`
 
@@ -438,12 +451,11 @@ The `player@v1_support` object in [`client/hello`](#client--server-clienthello) 
 
 The `player` object in [`client/state`](#client--server-clientstate) has this structure:
 
-Informs the server of player state changes. Only for clients with the `player` role.
+Informs the server of player-specific state changes. Only for clients with the `player` role.
 
 State updates must be sent whenever any state changes, including when the volume was changed through a `server/command` or via device controls.
 
 - `player`: object
-  - `state`: 'synchronized' | 'error' - state of the player, should always be `synchronized` unless there is an error preventing current or future playback (unable to keep up, issues keeping the clock in sync, etc)
   - `volume?`: integer - range 0-100, must be included if 'volume' is in `supported_commands` from [`player@v1_support`](#client--server-clienthello-playerv1-support-object)
   - `muted?`: boolean - mute state, must be included if 'mute' is in `supported_commands` from [`player@v1_support`](#client--server-clienthello-playerv1-support-object)
 
@@ -546,6 +558,8 @@ This ensures that when setting group volume to 100%, all players will reach 100%
 **Setting group mute:** When setting group mute via the 'mute' command, the server applies the mute state to all players in the group.
 
 #### Switch command cycle
+
+**Previous group priority:** If the client is still in the solo group from its `'external_source'` transition, the `switch` command prioritizes rejoining the previous group.
 
 For clients **with** the `player` role, the cycle includes:
 1. Multi-client groups that are currently playing

--- a/README.md
+++ b/README.md
@@ -332,10 +332,14 @@ When a client sets `state: 'external_source'`, it indicates the client's output 
 
 #### Server behavior when `state` changes to `'external_source'`:
 
+If the client is in a multi-client group:
 1. Remember the client's current group as its "previous group" (see [switch command cycle](#switch-command-cycle))
 2. Move the client to a new solo group (stopped)
    - Send [`group/update`](#server--client-groupupdate) with the new group information
    - Send [`stream/end`](#server--client-streamend) for all active streams
+
+If the client is already in a solo group:
+- Stop playback and send [`stream/end`](#server--client-streamend) for all active streams
 
 ### Client → Server: `client/command`
 

--- a/README.md
+++ b/README.md
@@ -321,14 +321,14 @@ For the initial message, include all state fields. For subsequent updates, only 
 - `state`: 'synchronized' | 'error' | 'external_source' - operational state of the client
   - `'synchronized'` - client is operational and synchronized with server timestamps
   - `'error'` - client has a problem preventing normal operation (unable to keep up, clock sync issues, etc.)
-  - `'external_source'` - client is in use by an external system and cannot participate in Sendspin playback. See [External Source Handling](#external-source-handling)
+  - `'external_source'` - client is in use by an external system and is not currently participating in Sendspin playback with this server. See [External Source Handling](#external-source-handling)
 - `player?`: object - only if client has `player` role ([see player state object details](#client--server-clientstate-player-object))
 
 [Application-specific roles](#application-specific-roles) may also include objects in this message (keys starting with `_`).
 
 ### External Source Handling
 
-When a client sets `state: 'external_source'`, it indicates the client's output is in use by an external system (e.g., a different audio source, HDMI input, or local media playback) and cannot participate in Sendspin playback.
+When a client sets `state: 'external_source'`, it indicates the client's output is in use by an external system (e.g., a different audio source, HDMI input, or local media playback) and is not currently participating in Sendspin playback with this server.
 
 #### Server behavior when `state` changes to `'external_source'`:
 


### PR DESCRIPTION
Adds `external_source` client state for when a device's output is in use by an external system (e.g., HDMI input, local media playback). Moves state from player object to client level. When a client transitions to external_source, it is moved to a stopped solo group and can rejoin its previous group via the switch command.