### PR TITLE
Add source@v1 role for audio input devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,6 +631,30 @@ The `source` object in [`server/command`](#server--client-servercommand) has thi
 
 All fields are optional. The server may send any subset (`command`, `control`, and/or `vad`) in one message.
 
+#### Source command semantics
+
+- `command` controls Sendspin ingest lifecycle for this source:
+  - `start`: server requests ingest to become active. The client should transition to `state: "streaming"`, send `input_stream/start`, and then send source audio chunks.
+  - `stop`: server requests ingest to become inactive. The client should send `input_stream/end`, stop sending source audio chunks, and transition to `state: "idle"`.
+- `control` is optional upstream-device control intent and only applies when advertised in `source@v1_support.controls`.
+  - `play` | `pause` | `next` | `previous`: control content playback behavior on the upstream source device (if supported).
+  - `activate` | `deactivate`: prepare or power-manage the upstream source path (for example power on/off, wake/sleep, input enable/disable).
+
+`start`/`stop` and `play`/`pause` are independent:
+
+- `start`/`stop` govern whether Sendspin ingest is active.
+- `play`/`pause` govern upstream content playback behavior.
+
+#### Default ingest behavior
+
+- Effective default after handshake is `stop` (ingest inactive).
+- Server ingest interest is represented by `command: "start"` / `command: "stop"`.
+- Server implementations should ignore/drop source binary chunks while ingest is not active.
+
+#### `vad` semantics
+
+`vad` is an optional server hint for source-side line-sense behavior (`threshold_db`, `hold_ms`). It allows centralized tuning and consistent behavior across sources/groups. Clients may ignore unsupported hints.
+
 Example `server/command` to start capture:
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -546,6 +546,7 @@ The `source@v1_support` object in [`client/hello`](#client--server-clienthello) 
     - `channels`: integer - number of channels (e.g., 1 = mono, 2 = stereo)
     - `sample_rate`: integer - sample rate in Hz (e.g., 44100, 48000)
     - `bit_depth`: integer - bit depth (e.g., 16, 24)
+  - `controls?`: string[] - optional source control commands supported by this client (subset of: 'play' | 'pause' | 'next' | 'previous' | 'activate' | 'deactivate')
   - `features?`: object - optional feature hints
     - `level?`: boolean - true if source reports `level`
     - `line_sense?`: boolean - true if source reports `signal`
@@ -577,6 +578,7 @@ Example `client/hello` excerpt:
           "bit_depth": 16
         }
       ],
+      "controls": ["play", "pause", "next", "previous", "activate", "deactivate"],
       "features": {
         "line_sense": true,
         "level": true
@@ -621,10 +623,13 @@ Source clients may send commands to inform the server about user-initiated captu
 The `source` object in [`server/command`](#server--client-servercommand) has this structure:
 
 - `source`: object
-  - `command`: 'start' | 'stop'
+  - `command?`: 'start' | 'stop'
+  - `control?`: 'play' | 'pause' | 'next' | 'previous' | 'activate' | 'deactivate' - optional source control command; ignored if unsupported by the client
   - `vad?`: object - optional VAD settings hint
     - `threshold_db?`: number - signal threshold in dB
     - `hold_ms?`: integer - hold time in milliseconds
+
+All fields are optional. The server may send any subset (`command`, `control`, and/or `vad`) in one message.
 
 Example `server/command` to start capture:
 ```json


### PR DESCRIPTION
**Summary**

This PR introduces a new source@v1 role to the Sendspin protocol, allowing audio input devices (e.g. line-in, turntable preamps, HDMI, Bluetooth receivers, microphones) to be represented and selected in a consistent, protocol-native way.

The goal is to enable remote audio inputs without increasing client complexity, while keeping the Sendspin server as the single place where all heavy processing happens.

All changes are additive and backward-compatible.

**Motivation**

Several real-world setups require audio to enter Sendspin from a device rather than originate inside the server:
	•	Line-in or turntable inputs connected to speakers or satellites
	•	HDMI / ARC inputs from TVs
	•	Bluetooth receivers acting as a local input
	•	Voice assistant or microphone satellites forwarding captured audio

Today the protocol focuses primarily on server-originated playback streams. This PR adds an additive source@v1 role to represent audio inputs as first-class sources, while keeping the server responsible for processing and distribution.

**Design overview**

The source role represents a client that:
	•	captures audio locally
	•	streams it to the server
	•	optionally reports basic signal presence or level
	•	does not perform any heavy processing

The server remains fully authoritative:
	•	resampling, transcoding, EQ
	•	buffering and synchronization
	•	visualization and distribution to players

Sources are intentionally kept simple so they can run on constrained devices.

**Input semantics**

Sources explicitly describe their behavior using two orthogonal concepts:

Input type
	•	analog – line-level style inputs (AUX, turntable preamp)
Audio presence depends on physical user interaction.
	•	digital – HDMI, S/PDIF, Bluetooth, or similar
Audio is usually continuous or remotely controllable.

Activation model
	•	manual – cannot be reliably started remotely (e.g. turntable)
	•	remote – server can start/stop capture predictably
	•	always_on – capture is always available

This allows controllers and UIs to behave sensibly without hard-coding device assumptions.

**Signal presence and feedback**

For analog inputs especially, it is important to avoid “playing silence”.
Therefore the role optionally supports:
	•	signal: present | absent | unknown (line sensing)
	•	level: normalized audio level (RMS/peak)

Both are optional and only reported if the source supports them.

**Controller integration**
	•	Controllers receive a list of available sources via server/state
	•	A new controller command select_source allows selecting an active source for a group
	•	Server-local inputs can be exposed as virtual source clients, using the same model

This keeps source selection aligned with existing group control concepts.

**Protocol changes (high level)**
	•	New role: source@v1
	•	Additions to:
	•	client/hello
	•	client/state
	•	client/command
	•	server/state
	•	server/command
	•	Binary message allocation for source audio frames
	•	Controller extensions for listing and selecting sources

No existing roles or message semantics are changed.

**Compatibility**
	•	Fully backward-compatible
	•	Existing clients and servers can ignore the new role
	•	No impact on playback, grouping, timing, or synchronization

**Open for feedback**

This proposal is meant as a starting point.

Feedback is very welcome on:
	•	field naming and structure
	•	activation semantics
	•	signal/level reporting
	•	whether anything should be simplified or removed
	
If parts of this feel out of scope or misaligned with Sendspin’s direction, I’m very happy to adjust or iterate.

If helpful, I am also happy to adapt or provide reference implementations.

Thanks for the great project and taking the time to review this.
	
	
	