### PR TITLE
Expand contrast guarantees of the `color@v1` role

### DIFF
--- a/README.md
+++ b/README.md
@@ -748,5 +748,5 @@ The `color` object in [`server/state`](#server--client-serverstate) has this str
   - `background_light?`: integer[] | null - background color suitable for light mode as `[R, G, B]` with values 0-255. The server must ensure a minimum WCAG contrast ratio of 4.5:1 with black text and with `on_light` (if also present).
   - `primary?`: integer[] | null - the dominant color, as `[R, G, B]` with values 0-255. Not adjusted for contrast.
   - `accent?`: integer[] | null - a secondary or complementary color, as `[R, G, B]` with values 0-255. Not adjusted for contrast.
-  - `on_dark?`: integer[] | null - a light color suitable for use on dark backgrounds, as `[R, G, B]` with values 0-255
-  - `on_light?`: integer[] | null - a dark color suitable for use on light backgrounds, as `[R, G, B]` with values 0-255
+  - `on_dark?`: integer[] | null - a light color suitable for use on dark backgrounds, as `[R, G, B]` with values 0-255. The server must ensure a minimum WCAG contrast ratio of 4.5:1 with `background_dark` (if also present) and with black text, so it can also serve as an alternative light background.
+  - `on_light?`: integer[] | null - a dark color suitable for use on light backgrounds, as `[R, G, B]` with values 0-255. The server must ensure a minimum WCAG contrast ratio of 4.5:1 with `background_light` (if also present) and with white text, so it can also serve as an alternative dark background.


### PR DESCRIPTION
While implementing the [Color Role](#70), I noticed that the contrast between `on_dark` and `on_light` with black and white text was too low.

I also tried implementing a minimum contrast between `accent` and both backgrounds, but in most cover artwork, there just wasn't a suitable accent color.

With this PR, the minimum contrast between `background_dark` and `on_dark` is also mentioned a second time in `on_dark`. However, this does not make the spec more strict, since this minimum contrast was already required.