### PR TITLE
Clarify client/state delta vs full updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ Client sends state updates to the server. Contains client-level state and role-s
 
 Must be sent immediately after receiving [`server/hello`](#server--client-serverhello), and whenever any state changes thereafter.
 
-For the initial message, include all state fields. For subsequent updates, only include fields that have changed. The server will merge these updates into existing state.
+The initial message MUST include all state fields. In subsequent messages, the client MAY send only the fields that have changed; the server MUST merge each update into existing state, retaining the last value of any field that is absent. A client MAY instead resend unchanged fields, up to its full state.
 
 - `state`: 'synchronized' | 'error' | 'external_source' - operational state of the client
   - `'synchronized'` - client is operational and synchronized with server timestamps
@@ -481,12 +481,14 @@ Informs the server of player-specific state changes. Only for clients with the `
 State updates must be sent whenever any state changes, including when the volume was changed through a `server/command` or via device controls.
 
 - `player`: object
-  - `volume?`: integer - range 0-100, must be included if 'volume' is in `supported_commands` from [`player@v1_support`](#client--server-clienthello-playerv1-support-object)
-  - `muted?`: boolean - mute state, must be included if 'mute' is in `supported_commands` from [`player@v1_support`](#client--server-clienthello-playerv1-support-object)
-  - `static_delay_ms`: integer - static delay in milliseconds (0-5000), always required for players
-  - `required_lead_time_ms`: integer - minimum startup lead time in milliseconds (e.g., codec init, decode warmup, audio backend buffering, DAC latency), always required for players. Measured from server transmit time of the start/restart trigger ([`stream/start`](#server--client-streamstart) or [`stream/clear`](#server--client-streamclear)) to the timestamp of the first subsequent audio chunk.
-  - `min_buffer_ms`: integer - requested minimum ongoing buffer duration in milliseconds during playback (primarily for live streams), used to absorb network jitter and ongoing decode/playback timing variance. Always required for players.
+  - `volume?`: integer - range 0-100, MUST be included if 'volume' is in `supported_commands` from [`player@v1_support`](#client--server-clienthello-playerv1-support-object)
+  - `muted?`: boolean - mute state, MUST be included if 'mute' is in `supported_commands` from [`player@v1_support`](#client--server-clienthello-playerv1-support-object)
+  - `static_delay_ms`: integer - static delay in milliseconds (0-5000), REQUIRED for players
+  - `required_lead_time_ms`: integer - minimum startup lead time in milliseconds (e.g., codec init, decode warmup, audio backend buffering, DAC latency), REQUIRED for players. Measured from server transmit time of the start/restart trigger ([`stream/start`](#server--client-streamstart) or [`stream/clear`](#server--client-streamclear)) to the timestamp of the first subsequent audio chunk.
+  - `min_buffer_ms`: integer - requested minimum ongoing buffer duration in milliseconds during playback (primarily for live streams), used to absorb network jitter and ongoing decode/playback timing variance. REQUIRED for players.
   - `supported_commands?`: string[] - subset of: 'set_static_delay'
+
+**Delta updates:** The presence requirements above (REQUIRED fields, and fields that MUST be included when a command is supported) describe a player's full state, reported in the initial message. In any later update a player MAY omit fields whose values have not changed, per the delta rules in [`client/state`](#client--server-clientstate).
 
 **Static delay:** The default is 0, meaning audio exits the device's audio port at the timestamp. `static_delay_ms` compensates for additional delay beyond the port (external speakers, amplifiers). Negative values are not supported and should never be required for any compliant implementation. Clients must persist `static_delay_ms` locally across reboots and server reconnections. Clients may update `static_delay_ms` and `supported_commands` when audio output changes (e.g., external speaker connected), persisting separate delays per output.
 


### PR DESCRIPTION
`client/state` said deltas "only include fields that have changed," but `static_delay_ms`, `required_lead_time_ms`, and `min_buffer_ms` were marked "always required for players." A delta changing one field can't satisfy both rules (#98). Separately, the spec didn't make clear whether a client may send full state instead of a delta, or what the server does with an absent field (#91, item 3).

Changes:

- Drop "always" from the three player fields and scope all field-presence rules to a player's full state.
- State the update model once: the initial message MUST be complete; later messages MAY send only changed fields; the server MUST merge and retain the last value of any absent field; a client MAY resend unchanged fields up to its full state.
- Replace the per-field delta wording with a single "Delta updates" note.
- Use RFC 2119 keywords in the affected passages.

A missing field always means "unchanged" — `client/state` has no null-clearing semantics, so the server never has to tell a delta apart from a full update; it merges either one the same way.

Out of scope: the other two items in #91 (default goodbye reason, `external_source` SDK API).

Closes #98
Refs #91