### PR TITLE
Simplify client/state status

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,7 +547,7 @@ Sent once the client is ready to report its operational `state`, and whenever an
 The initial message MUST include all state fields. In subsequent messages, the client MAY send only the fields that have changed; the server MUST merge each update into existing state, retaining the last value of any field that is absent. A client MAY instead resend unchanged fields, up to its full state.
 
 - `state`: 'synchronized' | 'external_source' - operational state of the client
-  - `'synchronized'` - client is operational and ready to participate in playback; for a player this means its clock is synchronized with the server. The server does not send timestamped binary data to a client until that client reports this state.
+  - `'synchronized'` - client is operational and ready to participate in playback; for a player this means its clock is synchronized with the server. The server MUST NOT send timestamped binary data to a client until that client reports this state.
   - `'external_source'` - client is in use by an external system and is not currently participating in Sendspin playback with this server. See [External Source Handling](#external-source-handling)
 - `player?`: object - only if client has `player` role ([see player state object details](#client--server-clientstate-player-object))
 

--- a/README.md
+++ b/README.md
@@ -542,12 +542,12 @@ For synchronization, all timing is relative to the server's monotonic clock. The
 
 Client sends state updates to the server. Contains client-level state and role-specific state objects.
 
-Sent once the client is ready to report its operational `state`, and whenever any state changes thereafter. A player sends its first `client/state` only after it has established [clock synchronization](#clock-synchronization). When a role becomes active in `active_roles`, send its full state.
+Sent once the client is ready to report its operational `state`, and whenever any state changes thereafter. A player sends its first `client/state` only after it has established [clock synchronization](#clock-synchronization). The server MUST NOT send binary data to a client before that client has sent its initial `client/state`. When a role becomes active in `active_roles`, send its full state.
 
 The initial message MUST include all state fields. In subsequent messages, the client MAY send only the fields that have changed; the server MUST merge each update into existing state, retaining the last value of any field that is absent. A client MAY instead resend unchanged fields, up to its full state.
 
 - `state`: 'synchronized' | 'external_source' - operational state of the client
-  - `'synchronized'` - client is operational and ready to participate in playback; for a player this means its clock is synchronized with the server. The server MUST NOT send timestamped binary data to a client until that client reports this state.
+  - `'synchronized'` - client is operational and ready to participate in playback; for a player this means its clock is synchronized with the server.
   - `'external_source'` - client is in use by an external system and is not currently participating in Sendspin playback with this server. See [External Source Handling](#external-source-handling)
 - `player?`: object - only if client has `player` role ([see player state object details](#client--server-clientstate-player-object))
 

--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ Binary audio messages contain timestamps in the server's time domain indicating 
 
 Each [`server/time`](#server--client-servertime) response provides the four timestamps needed by the filter: the client's transmitted timestamp, the server's received timestamp, the server's transmitted timestamp, and the client's receive time (captured locally when the response arrives). Clients feed these into the time filter via its `update` method and use its `compute_client_time` method to convert server timestamps to local clock values for playback scheduling.
 
-A player MUST send a `client/state` message with `state: 'synchronized'` once its time filter has converged enough to begin scheduling playback.
+A player MUST NOT report `state: 'synchronized'` until its time filter has converged enough to begin scheduling playback.
 
 ## Playback Synchronization
 
@@ -544,7 +544,7 @@ For synchronization, all timing is relative to the server's monotonic clock. The
 
 Client sends state updates to the server. Contains client-level state and role-specific state objects.
 
-Sent once the client is ready to report its operational `state`, and whenever any state changes thereafter. A player sends its first `client/state` only after it has established [clock synchronization](#clock-synchronization). The server MUST NOT send binary data to a client before that client has sent its initial `client/state`. When a role becomes active in `active_roles`, send its full state.
+Sent once the client is ready to report its operational `state`, and whenever any state changes thereafter. A player reports `state: 'synchronized'` only after it has established [clock synchronization](#clock-synchronization). The server MUST NOT send binary data to a client before that client has sent its initial `client/state`. When a role becomes active in `active_roles`, send its full state.
 
 The initial message MUST include all state fields. In subsequent messages, the client MAY send only the fields that have changed; the server MUST merge each update into existing state, retaining the last value of any field that is absent. A client MAY instead resend unchanged fields, up to its full state.
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,8 @@ Each [`server/time`](#server--client-servertime) response provides the four time
 
 - Each client is responsible for maintaining synchronization with the server's timestamps
 - Clients maintain accurate sync by adding or removing samples using interpolation to compensate for clock drift
-- When a client cannot maintain sync (e.g., buffer underrun), it should send `state: 'error'` via [`client/state`](#client--server-clientstate), mute its audio output, and continue buffering until it can resume synchronized playback, at which point it should send `state: 'synchronized'`
+- On connect a client reports `state: 'not_synchronized'` via [`client/state`](#client--server-clientstate), then `state: 'synchronized'` once clock synchronization is established. The server MUST NOT send binary messages to a client unless it is in the `synchronized` state
+- A buffer underrun does not change `state`; the client SHOULD mute output and continue buffering until it can resume synchronized playback
 - The server is unaware of individual client synchronization accuracy - it simply broadcasts timestamped audio
 - The server sends audio to late-joining clients with future timestamps only, allowing them to buffer and start playback in sync with existing clients
 - After sending [`stream/start`](#server--client-streamstart) or [`stream/clear`](#server--client-streamclear) messages, servers must schedule the first audio timestamp far enough in the future to satisfy each player's [`required_lead_time_ms`](#client--server-clientstate-player-object) (startup warmup) and [`min_buffer_ms`](#client--server-clientstate-player-object) (ongoing jitter buffer). For live streams the buffer cannot grow after playback begins, so the larger of the two must already be reached before the first chunk plays
@@ -192,7 +193,7 @@ sequenceDiagram
     Client->>Server: client/hello (roles and capabilities)
     Server->>Client: server/hello (server info, connection_reason)
 
-    Client->>Server: client/state (state: synchronized)
+    Client->>Server: client/state (state: not_synchronized)
     alt Player role
         Client->>Server: client/state (player: volume, muted)
     end
@@ -201,6 +202,9 @@ sequenceDiagram
         Client->>Server: client/time (client clock)
         Server->>Client: server/time (timing + offset info)
     end
+
+    Note over Client,Server: Client establishes clock synchronization
+    Client->>Server: client/state (state: synchronized)
 
     alt Stream starts
         Server->>Client: stream/start (codec, format details)
@@ -324,9 +328,9 @@ Must be sent immediately after receiving [`server/hello`](#server--client-server
 
 For the initial message, include all state fields. For subsequent updates, only include fields that have changed. The server will merge these updates into existing state.
 
-- `state`: 'synchronized' | 'error' | 'external_source' - operational state of the client
-  - `'synchronized'` - client is operational and synchronized with server timestamps
-  - `'error'` - client has a problem preventing normal operation (unable to keep up, clock sync issues, etc.)
+- `state`: 'synchronized' | 'not_synchronized' | 'external_source' - operational state of the client
+  - `'synchronized'` - client's clock is synchronized with the server; ready to receive timestamped binary data
+  - `'not_synchronized'` - client's clock is not yet synchronized with the server; the client's initial state until clock synchronization is established. The server does not send binary data to a client in this state
   - `'external_source'` - client is in use by an external system and is not currently participating in Sendspin playback with this server. See [External Source Handling](#external-source-handling)
 - `player?`: object - only if client has `player` role ([see player state object details](#client--server-clientstate-player-object))
 
@@ -535,7 +539,7 @@ When [`stream/clear`](#server--client-streamclear) includes the player role, cli
 
 ### Server → Client: Audio Chunks (Binary)
 
-Binary messages should be rejected if there is no active stream.
+Binary messages SHOULD be rejected if there is no active stream or the client is not in the `synchronized` [state](#client--server-clientstate).
 
 - Byte 0: message type `4` (uint8)
 - Bytes 1-8: timestamp (big-endian int64) - server clock time in microseconds when the first sample should be output
@@ -703,7 +707,7 @@ The `artwork` object in [`stream/start`](#server--client-streamstart) has this s
 
 ### Server → Client: Artwork (Binary)
 
-Binary messages should be rejected if there is no active stream.
+Binary messages SHOULD be rejected if there is no active stream or the client is not in the `synchronized` [state](#client--server-clientstate).
 
 - Byte 0: message type `8`-`11` (uint8) - corresponds to artwork channel 0-3 respectively
 - Bytes 1-8: timestamp (big-endian int64) - server clock time in microseconds when the image should be displayed by the device
@@ -773,7 +777,7 @@ When [`stream/clear`](#server--client-streamclear) includes the visualizer role,
 
 ### Server → Client: Visualization Data (Binary)
 
-Binary messages should be rejected if there is no active stream. Each visualization `type` has its own binary message type. Every message carries exactly one frame of `[timestamp:8][data]`:
+Binary messages SHOULD be rejected if there is no active stream or the client is not in the `synchronized` [state](#client--server-clientstate). Each visualization `type` has its own binary message type. Every message carries exactly one frame of `[timestamp:8][data]`:
 
 - Byte 0: message type (uint8, one of the types listed below)
 - Bytes 1-8: timestamp (big-endian int64) - server clock time in microseconds when this data should be displayed. Clients must translate this server timestamp to their local clock using the offset computed from clock synchronization

--- a/README.md
+++ b/README.md
@@ -286,6 +286,8 @@ Binary audio messages contain timestamps in the server's time domain indicating 
 
 Each [`server/time`](#server--client-servertime) response provides the four timestamps needed by the filter: the client's transmitted timestamp, the server's received timestamp, the server's transmitted timestamp, and the client's receive time (captured locally when the response arrives). Clients feed these into the time filter via its `update` method and use its `compute_client_time` method to convert server timestamps to local clock values for playback scheduling.
 
+A player MUST send a `client/state` message with `state: 'synchronized'` once its time filter has converged enough to begin scheduling playback.
+
 ## Playback Synchronization
 
 This section defines rules that require all implementations to provide a good experience, keeping playback seamlessly synchronized between speakers. While implementations can choose their own strategy, this section describes the minimal requirements that must be met by players. For a recommended strategy that is compliant, see the [Suggested correction strategy](#suggested-correction-strategy) subsection below.

--- a/README.md
+++ b/README.md
@@ -350,18 +350,13 @@ sequenceDiagram
     Client->>Server: client/hello (roles and capabilities)
     Server->>Client: server/activate (activities, active_roles)
 
-    Client->>Server: client/state (state: not_synchronized)
-    alt Player role
-        Client->>Server: client/state (player: volume, muted)
-    end
-
     loop Continuous clock sync
         Client->>Server: client/time (client clock)
         Server->>Client: server/time (timing + offset info)
     end
 
-    Note over Client,Server: Client establishes clock synchronization
-    Client->>Server: client/state (state: synchronized)
+    Note over Client,Server: Clock synchronization established
+    Client->>Server: client/state (state: synchronized, player: volume, muted)
 
     alt Stream starts
         Server->>Client: stream/start (codec, format details)
@@ -547,13 +542,12 @@ For synchronization, all timing is relative to the server's monotonic clock. The
 
 Client sends state updates to the server. Contains client-level state and role-specific state objects.
 
-Must be sent after the initial [`server/activate`](#server--client-serveractivate), and whenever any state changes thereafter. When a role becomes active in `active_roles`, send its full state.
+Sent once the client is ready to report its operational `state`, and whenever any state changes thereafter. A player sends its first `client/state` only after it has established [clock synchronization](#clock-synchronization). When a role becomes active in `active_roles`, send its full state.
 
 The initial message MUST include all state fields. In subsequent messages, the client MAY send only the fields that have changed; the server MUST merge each update into existing state, retaining the last value of any field that is absent. A client MAY instead resend unchanged fields, up to its full state.
 
-- `state`: 'synchronized' | 'not_synchronized' | 'external_source' - operational state of the client
-  - `'synchronized'` - client's clock is synchronized with the server; ready to receive timestamped binary data
-  - `'not_synchronized'` - client's clock is not yet synchronized with the server; the client's initial state until clock synchronization is established. The server does not send binary data to a client in this state
+- `state`: 'synchronized' | 'external_source' - operational state of the client
+  - `'synchronized'` - client is operational and ready to participate in playback; for a player this means its clock is synchronized with the server. The server does not send timestamped binary data to a client until that client reports this state.
   - `'external_source'` - client is in use by an external system and is not currently participating in Sendspin playback with this server. See [External Source Handling](#external-source-handling)
 - `player?`: object - only if client has `player` role ([see player state object details](#client--server-clientstate-player-object))
 


### PR DESCRIPTION
Reworks the client state model so a client reports synchronization status rather than errors.

- Removes the `error` state
- Clients only send the initial `client/state` message when time is synchronized
- The server MUST NOT send binary messages (audio, artwork, visualization) to a client until the client reports the synchronized state. Each binary section now rejects messages outside that state.
- Drops error reporting for transient playback issues: a buffer underrun no longer changes state, so clients don't report temporary audible/visual sync hiccups.

Updates the `client/state` enum, the Playback Synchronization rules, and the handshake sequence diagram (send first `client/state` only after time synchronization is established).

Ref #88 (addresses point 3 by dropping the `error` state on underflow)