### PR TITLE
Define minimum sync standards for the `player@v1` role

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,44 +318,25 @@ Each client is responsible for maintaining its own synchronization with the serv
 
 ### Suggested correction strategy
 
-This is one valid correction strategy for clients with the `player` role: a per-chunk push model. It is an example, not a requirement. New implementers can use it as a starting point, especially on platforms where CPU or memory usage is limited.
+This is one valid correction strategy for clients with the `player` role: discrete sample deletion and insertion. It is an example, not a requirement. New implementers can use it as a starting point, especially where CPU or memory is limited: it needs no interpolation and leaves the audio bit-exact except at the moments it corrects.
 
-Other strategies are allowed as long as they meet the rules in this section.
+Other strategies are allowed and encouraged as long as they meet the rules in this section. For example, asynchronous sample-rate conversion (ASRC) continuously resamples the stream to track the clock, trading CPU/DSP load for lower steady-state distortion than discrete frame drops.
 
-#### Per-chunk push model
+#### Sample deletion and insertion
 
-This strategy combines two mechanisms: **soft sync** handles small steady-state drift in approximately 21 µs increments per chunk, and **hard sync** handles larger one-shot errors. A "frame" is one sample across all channels (e.g. one stereo pair).
+The player renders decoded frames at their server timestamps translated to local time by the time-filter, and corrects accumulated drift by occasionally deleting or duplicating whole frames. At realistic clock drift these corrections are small and infrequent (a few per second) and individually inaudible. A "frame" is one sample across all channels (e.g. one stereo pair).
 
-**Soft sync.** Per decoded chunk:
+**Soft correction.** Per decoded chunk:
 
-1. Measure the time error between when the chunk is scheduled to play (the chunk's server timestamp translated to local time via the time-filter) and where the renderer will reach the chunk in its output buffer.
-2. If the absolute error is below the soft-sync dead band (100 µs), pass the chunk through unmodified.
-3. Otherwise, apply approximately 21 µs of correction at the chunk's end by inserting (positive error) or dropping (negative error) `N` frames, where `N = round(21 µs × sample_rate_hz / 1,000,000)`. At common sample rates: N=1 at 44.1 kHz and 48 kHz, N=2 at 96 kHz, N=4 at 192 kHz.
-4. Output the modified chunk. Residual error beyond ~21 µs carries over to subsequent chunks.
+1. Measure the time error between when the chunk is scheduled to play (its server timestamp via the time-filter) and where the renderer will reach it in the output buffer.
+2. If the absolute error is below the dead band (~100 µs), output the chunk unchanged.
+3. Otherwise correct by `N` frames: if playback is running late (the chunk reaches the output after its scheduled local time), drop `N` frames to catch up; if running early, duplicate `N` frames to wait. Residual error beyond the step carries to the next chunk.
 
-**Insert N frames at the chunk's end.** Let the chunk consist of frames `F[0], F[1], ..., F[L-1]` with `L ≥ 2`. Generate N intermediate frames between `F[L-2]` and `F[L-1]` using linear interpolation. For each `i` from 1 to N, per channel `c`:
+**Choosing N.** Use the smallest `N` that keeps up with drift, scaled to hold the step duration constant across sample rates: `N = round(21 µs × sample_rate_hz / 1,000,000)` (N=1 at 44.1 and 48 kHz, 2 at 96 kHz, 4 at 192 kHz). A chunk's correction MUST NOT exceed the ±0.5% speed cap, so `N ≤ floor(0.005 × samples_in_chunk)`. Keep `N` small; at realistic drift any `N` in this range stays masked.
 
-```
-M_i[c] = ((N+1-i) × F[L-2][c] + i × F[L-1][c]) / (N+1)
-```
+**Drop** removes the `N` frames and lets the neighbouring frames abut. **Duplicate** repeats a boundary frame `N` times. The output is the original samples with `N` removed or `N` repeated, bit-exact everywhere else.
 
-Insert all N between `F[L-2]` and `F[L-1]`. Output sequence: `F[0], ..., F[L-2], M_1, M_2, ..., M_N, F[L-1]`. Length: `L + N`. For N=1 this reduces to `M_1 = (F[L-2] + F[L-1]) / 2`, the per-channel mean.
-
-**Drop N frames at the chunk's end.** Replace the last N+1 original frames with a single frame equal to their per-channel average:
-
-```
-M[c] = (F[L-N-1][c] + F[L-N][c] + ... + F[L-1][c]) / (N+1)
-```
-
-Output sequence: `F[0], ..., F[L-N-2], M`. Length: `L - N`. For N=1 this reduces to `M = (F[L-2] + F[L-1]) / 2`, replacing the second-to-last frame and discarding the last.
-
-Compute all intermediate values at a precision at least as high as the source samples (e.g. expand to signed 32-bit, compute, repack) to avoid overflow at full-scale samples.
-
-**Hard sync.** When the measured error exceeds 2 ms, apply a one-shot correction *before* soft sync runs on the chunk:
-- Audio ahead of schedule (negative error): drop a leading prefix of the chunk equal to the time excess.
-- Audio behind schedule (positive error): insert silence of equivalent duration before the chunk.
-
-Hard sync introduces a brief audible discontinuity by design and should be rare; soft sync handles steady-state drift.
+**Large errors and startup.** When the error would otherwise exceed the ±2 ms floor, or on startup, [`stream/start`](#server--client-streamstart), [`stream/clear`](#server--client-streamclear), or recovery from underrun, snap to the correct position in one shot instead of soft-correcting: if playback is late, drop a leading prefix equal to the excess; if early, insert silence of the equivalent duration. This is a deliberate discontinuity and MUST be rare.
 
 ```mermaid
 sequenceDiagram

--- a/README.md
+++ b/README.md
@@ -291,8 +291,8 @@ This section defines rules that require all implementations to provide a good ex
 
 ### Correction Quality
 
-- **Smooth corrections:** In steady state, every correction applied to the audio output MUST avoid audible discontinuities (clicks, zipper noise, or similar artifacts). Implementations that work by simply adding or removing discrete samples MUST interpolate or blend across the affected region.
-- **Maximum speed deviation:** The effective playback speed MUST stay within ±0.5% of normal speed. Applies at all times during playback, including recovery from disturbances.
+- **Inaudible corrections:** In steady state, individual corrections MUST NOT produce audible noise, warble, or distortion during normal listening.
+- **Maximum speed deviation:** The effective playback speed MUST stay within ±0.5% of normal speed, measured as a sliding average over 150 ms. This bounds continuous (steady-state) correction. A discrete one-shot resynchronization after a disturbance (startup, buffer underrun, or an error too large to correct smoothly) is not a speed deviation and is exempt; such events MUST be rare.
 
 ### Sync Accuracy
 
@@ -300,7 +300,7 @@ Sync accuracy is measured at the audio output, against what the time-filter pred
 
 Each client is responsible for maintaining its own synchronization with the server's timestamps.
 
-- **Accuracy floor:** Implementations MUST keep this error within ±2 ms.
+- **Accuracy floor:** In steady state, implementations MUST keep this error within ±2 ms. The only exception is the one-shot resynchronization exempted from the speed cap above, which MUST be rare.
 - **Accuracy target:** Implementations SHOULD aim for ±1 ms.
 - Clients subtract their [`static_delay_ms`](#client--server-clientstate-player-object) from server timestamps before scheduling playback.
 - Audio chunks may arrive with timestamps in the past due to network delays or buffering; clients should drop these late chunks to maintain sync.

--- a/README.md
+++ b/README.md
@@ -300,8 +300,8 @@ Sync accuracy is measured at the audio output, against what the time-filter pred
 
 Each client is responsible for maintaining its own synchronization with the server's timestamps.
 
-- **Accuracy floor:** In steady state, implementations MUST keep this error within ±2 ms. The only exception is the one-shot resynchronization exempted from the speed cap above, which MUST be rare.
-- **Accuracy target:** Implementations SHOULD aim for ±1 ms.
+- **Accuracy floor:** In steady state, implementations MUST keep this error within ±1 ms. The only exception is the one-shot resynchronization exempted from the speed cap above, which MUST be rare.
+- **Accuracy target:** Implementations SHOULD aim for ±0.5 ms.
 - Clients subtract their [`static_delay_ms`](#client--server-clientstate-player-object) from server timestamps before scheduling playback.
 - Audio chunks may arrive with timestamps in the past due to network delays or buffering; clients should drop these late chunks to maintain sync.
 
@@ -336,7 +336,7 @@ The player renders decoded frames at their server timestamps translated to local
 
 **Drop** removes the `N` frames and lets the neighbouring frames abut. **Duplicate** repeats a boundary frame `N` times. The output is the original samples with `N` removed or `N` repeated, bit-exact everywhere else.
 
-**Large errors and startup.** When the error would otherwise exceed the ±2 ms floor, or on startup, [`stream/start`](#server--client-streamstart), [`stream/clear`](#server--client-streamclear), or recovery from underrun, snap to the correct position in one shot instead of soft-correcting: if playback is late, drop a leading prefix equal to the excess; if early, insert silence of the equivalent duration. This is a deliberate discontinuity and MUST be rare.
+**Large errors and startup.** When the error would otherwise exceed the ±1 ms floor, or on startup, [`stream/start`](#server--client-streamstart), [`stream/clear`](#server--client-streamclear), or recovery from underrun, snap to the correct position in one shot instead of soft-correcting: if playback is late, drop a leading prefix equal to the excess; if early, insert silence of the equivalent duration. This is a deliberate discontinuity and MUST be rare.
 
 ```mermaid
 sequenceDiagram

--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ Each client is responsible for maintaining its own synchronization with the serv
 
 ### Server Audio Send Constraints
 
-- **Chunk duration cap:** A server MUST NOT send an audio chunk longer than 150 ms in duration, regardless of codec, sample rate, or stream type. Duration is `(samples_in_chunk / sample_rate_hz) * 1000` ms.
+- **Chunk duration bounds:** A server MUST NOT send an audio chunk longer than 150 ms, and SHOULD NOT send one shorter than 15 ms (the final chunk of a stream or the chunk before a format change MAY be shorter).
 - The server sends audio to late-joining clients with future timestamps only, allowing them to buffer and start playback in sync with existing clients.
 - After sending [`stream/start`](#server--client-streamstart) or [`stream/clear`](#server--client-streamclear) messages, servers must schedule the first audio timestamp far enough in the future to satisfy each player's [`required_lead_time_ms`](#client--server-clientstate-player-object) (startup warmup) and [`min_buffer_ms`](#client--server-clientstate-player-object) (ongoing jitter buffer). For live streams the buffer cannot grow after playback begins, so the larger of the two must already be reached before the first chunk plays.
 - Servers factor in each client's [`static_delay_ms`](#client--server-clientstate-player-object) when calculating how far ahead to send audio, keeping effective buffer headroom constant.

--- a/README.md
+++ b/README.md
@@ -279,23 +279,83 @@ The concatenated `data` from all fragments yields the original message's payload
 
 ## Clock Synchronization
 
-Clients continuously send `client/time` messages to maintain an accurate offset from the server's clock. The frequency of these messages is determined by the client based on network conditions and clock stability.
+Clients send `client/time` messages to maintain an accurate offset from the server's clock. Implementations MUST send these messages frequently enough to keep the filter convergent. See the time-filter library's [Recommended Usage](https://github.com/Sendspin-Protocol/time-filter#recommended-usage) section for a known-good burst-strategy baseline.
 
-Binary audio messages contain timestamps in the server's time domain indicating when the audio should be played. Clients must use the [time-filter](https://github.com/Sendspin-Protocol/time-filter) algorithm to translate server timestamps to their local clock for synchronized playback. The time filter is a two-dimensional Kalman filter that tracks both clock offset and drift. See the [time-filter](https://github.com/Sendspin-Protocol/time-filter) repository for a C++ reference implementation and [aiosendspin](https://github.com/Sendspin-Protocol/aiosendspin/blob/main/aiosendspin/client/time_sync.py) for a Python implementation.
+Binary audio messages contain timestamps in the server's time domain indicating when the audio should be played. Clients MUST use the [time-filter](https://github.com/Sendspin-Protocol/time-filter) algorithm to translate server timestamps to their local clock for synchronized playback. The time filter is a two-dimensional Kalman filter that tracks both clock offset and drift. See the [time-filter](https://github.com/Sendspin-Protocol/time-filter) repository for a C++ reference implementation and [aiosendspin](https://github.com/Sendspin-Protocol/aiosendspin/blob/main/aiosendspin/client/time_sync.py) for a Python implementation.
 
 Each [`server/time`](#server--client-servertime) response provides the four timestamps needed by the filter: the client's transmitted timestamp, the server's received timestamp, the server's transmitted timestamp, and the client's receive time (captured locally when the response arrives). Clients feed these into the time filter via its `update` method and use its `compute_client_time` method to convert server timestamps to local clock values for playback scheduling.
 
 ## Playback Synchronization
 
-- Each client is responsible for maintaining synchronization with the server's timestamps
-- Clients maintain accurate sync by adding or removing samples using interpolation to compensate for clock drift
-- When a client cannot maintain sync (e.g., buffer underrun), it should send `state: 'error'` via [`client/state`](#client--server-clientstate), mute its audio output, and continue buffering until it can resume synchronized playback, at which point it should send `state: 'synchronized'`
-- The server is unaware of individual client synchronization accuracy - it simply broadcasts timestamped audio
-- The server sends audio to late-joining clients with future timestamps only, allowing them to buffer and start playback in sync with existing clients
-- After sending [`stream/start`](#server--client-streamstart) or [`stream/clear`](#server--client-streamclear) messages, servers must schedule the first audio timestamp far enough in the future to satisfy each player's [`required_lead_time_ms`](#client--server-clientstate-player-object) (startup warmup) and [`min_buffer_ms`](#client--server-clientstate-player-object) (ongoing jitter buffer). For live streams the buffer cannot grow after playback begins, so the larger of the two must already be reached before the first chunk plays
-- Audio chunks may arrive with timestamps in the past due to network delays or buffering; clients should drop these late chunks to maintain sync
-- Clients subtract their [`static_delay_ms`](#client--server-clientstate-player-object) from server timestamps before scheduling playback
-- Servers factor in each client's `static_delay_ms` when calculating how far ahead to send audio, keeping effective buffer headroom constant
+This section defines rules that require all implementations to provide a good experience, keeping playback seamlessly synchronized between speakers. While implementations can choose their own strategy, this section describes the minimal requirements that must be met by players. For a recommended strategy that is compliant, see the [Suggested correction strategy](#suggested-correction-strategy) subsection below.
+
+### Correction Quality
+
+- **Smooth corrections:** In steady state, every correction applied to the audio output MUST avoid audible discontinuities (clicks, zipper noise, or similar artifacts). Implementations that work by simply adding or removing discrete samples MUST interpolate or blend across the affected region.
+- **Maximum speed deviation:** The effective playback speed MUST stay within ±0.5% of normal speed. Applies at all times during playback, including recovery from disturbances.
+
+### Sync Accuracy
+
+Sync accuracy is measured at the audio output, against what the time-filter predicts the local time should be (not against the true server clock). Use of the [time-filter](#clock-synchronization) is required to meet these minimum standards. The error is the absolute difference between when a sample actually plays in the client's local clock and the local time the time-filter predicts for that sample's server timestamp.
+
+Each client is responsible for maintaining its own synchronization with the server's timestamps.
+
+- **Accuracy floor:** Implementations MUST keep this error within ±2 ms.
+- **Accuracy target:** Implementations SHOULD aim for ±1 ms.
+- Clients subtract their [`static_delay_ms`](#client--server-clientstate-player-object) from server timestamps before scheduling playback.
+- Audio chunks may arrive with timestamps in the past due to network delays or buffering; clients should drop these late chunks to maintain sync.
+
+### Startup Behavior
+
+- **No startup warble:** During startup, the client MUST NOT produce audible pitch modulation, warble, or other transient artifacts in the audio output.
+
+### Server Audio Send Constraints
+
+- **Chunk duration cap:** A server MUST NOT send an audio chunk longer than 150 ms in duration, regardless of codec, sample rate, or stream type. Duration is `(samples_in_chunk / sample_rate_hz) * 1000` ms.
+- The server sends audio to late-joining clients with future timestamps only, allowing them to buffer and start playback in sync with existing clients.
+- After sending [`stream/start`](#server--client-streamstart) or [`stream/clear`](#server--client-streamclear) messages, servers must schedule the first audio timestamp far enough in the future to satisfy each player's [`required_lead_time_ms`](#client--server-clientstate-player-object) (startup warmup) and [`min_buffer_ms`](#client--server-clientstate-player-object) (ongoing jitter buffer). For live streams the buffer cannot grow after playback begins, so the larger of the two must already be reached before the first chunk plays.
+- Servers factor in each client's [`static_delay_ms`](#client--server-clientstate-player-object) when calculating how far ahead to send audio, keeping effective buffer headroom constant.
+
+### Suggested correction strategy
+
+This is one valid correction strategy for clients with the `player` role: a per-chunk push model. It is an example, not a requirement. New implementers can use it as a starting point, especially on platforms where CPU or memory usage is limited.
+
+Other strategies are allowed as long as they meet the rules in this section.
+
+#### Per-chunk push model
+
+This strategy combines two mechanisms: **soft sync** handles small steady-state drift in approximately 21 µs increments per chunk, and **hard sync** handles larger one-shot errors. A "frame" is one sample across all channels (e.g. one stereo pair).
+
+**Soft sync.** Per decoded chunk:
+
+1. Measure the time error between when the chunk is scheduled to play (the chunk's server timestamp translated to local time via the time-filter) and where the renderer will reach the chunk in its output buffer.
+2. If the absolute error is below the soft-sync dead band (100 µs), pass the chunk through unmodified.
+3. Otherwise, apply approximately 21 µs of correction at the chunk's end by inserting (positive error) or dropping (negative error) `N` frames, where `N = round(21 µs × sample_rate_hz / 1,000,000)`. At common sample rates: N=1 at 44.1 kHz and 48 kHz, N=2 at 96 kHz, N=4 at 192 kHz.
+4. Output the modified chunk. Residual error beyond ~21 µs carries over to subsequent chunks.
+
+**Insert N frames at the chunk's end.** Let the chunk consist of frames `F[0], F[1], ..., F[L-1]` with `L ≥ 2`. Generate N intermediate frames between `F[L-2]` and `F[L-1]` using linear interpolation. For each `i` from 1 to N, per channel `c`:
+
+```
+M_i[c] = ((N+1-i) × F[L-2][c] + i × F[L-1][c]) / (N+1)
+```
+
+Insert all N between `F[L-2]` and `F[L-1]`. Output sequence: `F[0], ..., F[L-2], M_1, M_2, ..., M_N, F[L-1]`. Length: `L + N`. For N=1 this reduces to `M_1 = (F[L-2] + F[L-1]) / 2`, the per-channel mean.
+
+**Drop N frames at the chunk's end.** Replace the last N+1 original frames with a single frame equal to their per-channel average:
+
+```
+M[c] = (F[L-N-1][c] + F[L-N][c] + ... + F[L-1][c]) / (N+1)
+```
+
+Output sequence: `F[0], ..., F[L-N-2], M`. Length: `L - N`. For N=1 this reduces to `M = (F[L-2] + F[L-1]) / 2`, replacing the second-to-last frame and discarding the last.
+
+Compute all intermediate values at a precision at least as high as the source samples (e.g. expand to signed 32-bit, compute, repack) to avoid overflow at full-scale samples.
+
+**Hard sync.** When the measured error exceeds 2 ms, apply a one-shot correction *before* soft sync runs on the chunk:
+- Audio ahead of schedule (negative error): drop a leading prefix of the chunk equal to the time excess.
+- Audio behind schedule (positive error): insert silence of equivalent duration before the chunk.
+
+Hard sync introduces a brief audible discontinuity by design and should be rare; soft sync handles steady-state drift.
 
 ```mermaid
 sequenceDiagram


### PR DESCRIPTION
The specification didn't exactly define a minimum bar for synced playback. That meant that terribly out-of-sync players were still valid, while their end-user experience was unusable when grouped with other Sendspin players.

The new rules:

- require the use of time-filter and the bursting strategy
- `client/time` cadence floor
- inaudible corrections in steady state
- max ±0.5% speed in steady state (sliding average over the maximum chunk size, 150 ms)
- ±1 ms accuracy in steady state
- a rare one-shot resync (startup, underrun, large disturbance) is exempt from the speed and accuracy bounds
- no startup warble
- server chunk duration bounded to 15-150 ms (covers Opus at 20 ms and FLAC at 105 ms)

To give a head start for new implementations, this PR also adds a simple suggested strategy: discrete, bit-exact sample deletion and insertion. The player drops or duplicates whole frames to correct drift, leaving the audio untouched except at the moments it corrects. N scales with sample rate. Other algorithms like ASRC are still encouraged.

## Constants

- Maximum speed deviation ±0.5%: tighter than the cli's old ±4% warble; looser than what cpp/cli hold today (~0.1%/~0.2%). This is a ~8.6 cent pitch shift, on the edge of being inaudible with music. In steady state pitch tracks clock drift, so this cap is rarely reached.
- Accuracy floor ±1 ms: achievable continuously by native clients and the Python implementation `sendspin-cli`.
- Accuracy target ±0.5 ms: in-room target, enough so individual speakers are not discernible when grouped.
- Chunk duration bounds 15-150 ms: the 150 ms cap gives headroom over `aiosendspin`'s current 105 ms max (FLAC at 44.1 kHz). The 15 ms floor keeps enough samples per chunk to correct within the ±0.5% cap.
- Soft correction baseline ≈21 µs per chunk: one frame at 48 kHz, scaled by sample rate. Implementations may use a larger step to keep up with drift, bounded by the ±0.5% cap.
- Dead band 100 µs: matches sendspin-cpp's existing value.
- One-shot resync threshold 1 ms: set equal to the accuracy floor so the snap fires before the floor is violated.

## Related issues

- #88
- #89
