### PR TITLE
Add `source` role for audio input clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -1194,7 +1194,6 @@ The `source@v1_support` object in [`client/hello`](#client--server-clienthello) 
 The `source` object in [`client/state`](#client--server-clientstate) has this structure:
 
 - `source`: object
-  - `state`: 'idle' | 'streaming' - whether the source is currently capturing and sending audio
   - `signal?`: 'present' | 'absent' - optional line sensing/signal presence, only if 'line_sense' is supported
 
 ### Server → Client: `server/command` source object
@@ -1207,17 +1206,17 @@ The `source` object in [`server/command`](#server--client-servercommand) has thi
 #### Source command semantics
 
 - `command` controls Sendspin ingest lifecycle for this source:
-  - `start`: server requests ingest to become active. The client SHOULD transition to `state: "streaming"`, send `input_stream/start`, and then send source audio chunks.
-  - `stop`: server requests ingest to become inactive. The client SHOULD send `input_stream/end`, stop sending source audio chunks, and transition to `state: "idle"`.
+  - `start`: server requests ingest to become active. The client SHOULD send `input_stream/start` and then send source audio chunks.
+  - `stop`: server requests ingest to become inactive. The client SHOULD send `input_stream/end` and stop sending source audio chunks.
 
 #### Default ingest behavior
 
 - Effective default after handshake is `stop` (ingest inactive).
 - Server ingest interest is represented by `command: "start"` / `command: "stop"`.
 
-A source MAY also start ingest on its own without waiting for `command: "start"`: it transitions to `state: "streaming"`, sends `input_stream/start`, and begins sending chunks. This lets a source that detects local signal (e.g., a turntable starting) begin streaming immediately, with no `signal`-to-`start` round trip. The server infers a source-initiated start from the `input_stream/start` it did not request, decides whether to route or drop the stream per its own policy, and a source MUST still honor a subsequent `command: "stop"`.
+A source MAY also start ingest on its own without waiting for `command: "start"`: it sends `input_stream/start` and begins sending chunks. This lets a source that detects local signal (e.g., a turntable starting) begin streaming immediately, with no `signal`-to-`start` round trip. The server infers a source-initiated start from the `input_stream/start` it did not request, decides whether to route or drop the stream per its own policy, and a source MUST still honor a subsequent `command: "stop"`.
 
-A source MAY likewise stop on its own (e.g., the input goes silent): it sends `input_stream/end`, stops sending chunks, and reports `state: "idle"`.
+A source MAY likewise stop on its own (e.g., the input goes silent): it sends `input_stream/end` and stops sending chunks.
 
 When the server removes `source` from [`active_roles`](#server--client-serveractivate), the client sends `input_stream/end` and stops sending chunks.
 

--- a/README.md
+++ b/README.md
@@ -1285,6 +1285,8 @@ The `source` object in [`server/command`](#server--client-servercommand) has thi
 - Server ingest interest is represented by `command: "start"` / `command: "stop"`.
 - Server implementations should ignore/drop source binary chunks while ingest is not active.
 
+A source MAY also start ingest on its own without waiting for `command: "start"`: it transitions to `state: "streaming"`, sends `input_stream/start`, and begins sending chunks. This lets a source that detects local signal (e.g., a turntable starting) begin streaming immediately, with no `signal`-to-`start` round trip. The server decides whether to route or drop the stream per its own policy, and a source MUST still honor a subsequent `command: "stop"`.
+
 Example `server/command` to start capture:
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -1185,6 +1185,8 @@ This section describes messages specific to clients with the `source` role, whic
 
 A source client uses the same clock synchronization mechanism as all clients. Binary source audio messages are timestamped in the **server time domain** using the clock offset learned from `client/time`/`server/time`.
 
+**Pairing required:** A source streams captured audio (potentially from a microphone or line-in) to the server, so it MUST only run on a paired connection ([trust level](#definitions) `user`). Servers MUST NOT activate `source@v1` over [unpaired access](#unpaired-access), and a source client MUST refuse to stream when the connection's trust level is `none`.
+
 ### Client → Server: `client/hello` source@v1 support object
 
 The `source@v1_support` object in [`client/hello`](#client--server-clienthello) has this structure:

--- a/README.md
+++ b/README.md
@@ -1205,16 +1205,16 @@ The `source` object in [`server/command`](#server--client-servercommand) has thi
 
 #### Source command semantics
 
-- `command` controls Sendspin ingest lifecycle for this source:
-  - `start`: server requests ingest to become active. The client SHOULD send `input_stream/start` and then send source audio chunks.
-  - `stop`: server requests ingest to become inactive. The client SHOULD send `input_stream/end` and stop sending source audio chunks.
+- `command` controls whether this source streams to the server:
+  - `start`: server requests the source to begin streaming. The client SHOULD send `input_stream/start` and then send source audio chunks.
+  - `stop`: server requests the source to stop streaming. The client SHOULD send `input_stream/end` and stop sending source audio chunks.
 
-#### Default ingest behavior
+#### Default streaming behavior
 
-- Effective default after handshake is `stop` (ingest inactive).
-- Server ingest interest is represented by `command: "start"` / `command: "stop"`.
+- Effective default after handshake is `stop` (not streaming).
+- The server signals whether it wants this source's audio with `command: "start"` / `command: "stop"`.
 
-A source MAY also start ingest on its own without waiting for `command: "start"`: it sends `input_stream/start` and begins sending chunks. This lets a source that detects local signal (e.g., a turntable starting) begin streaming immediately, with no `signal`-to-`start` round trip. The server infers a source-initiated start from the `input_stream/start` it did not request, decides whether to route or drop the stream per its own policy, and a source MUST still honor a subsequent `command: "stop"`.
+A source MAY also start streaming on its own without waiting for `command: "start"`: it sends `input_stream/start` and begins sending chunks. This lets a source that detects local signal (e.g., a turntable starting) begin streaming immediately, with no `signal`-to-`start` round trip. The server infers a source-initiated start from the `input_stream/start` it did not request, decides whether to route or drop the stream per its own policy, and a source MUST still honor a subsequent `command: "stop"`.
 
 A source MAY likewise stop on its own (e.g., the input goes silent): it sends `input_stream/end` and stops sending chunks.
 

--- a/README.md
+++ b/README.md
@@ -1177,7 +1177,7 @@ Sources are intended to be simple:
 
 A device may implement both `source` and `player` roles (e.g., a speaker with a local AUX input that can be forwarded into Sendspin).
 
-The server may also expose **built-in inputs** (e.g., a line-in on the server host, or an HDMI capture device connected to the server) as a **virtual source client**. Virtual sources participate in the same source selection and state model as regular source clients and appear in the controller `sources` list.
+The server may also expose **built-in inputs** (e.g., a line-in on the server host, or an HDMI capture device connected to the server) as a **virtual source client**. Virtual sources participate in the same source selection and state model as regular source clients.
 
 ## Source messages
 
@@ -1244,7 +1244,7 @@ The `source` object in [`client/state`](#client--server-clientstate) has this st
 - `source`: object
   - `state`: 'idle' | 'streaming' | 'error'
   - `level?`: number - optional normalized RMS/peak level (0.0-1.0), only if 'level' is supported
-  - `signal?`: 'unknown' | 'present' | 'absent' - optional line sensing/signal presence, only if 'line_sense' is supported
+  - `signal?`: 'present' | 'absent' - optional line sensing/signal presence, only if 'line_sense' is supported
 
 Example `client/state` excerpt:
 ```json
@@ -1274,11 +1274,8 @@ The `source` object in [`server/command`](#server--client-servercommand) has thi
 - `source`: object
   - `command?`: 'start' | 'stop'
   - `control?`: 'play' | 'pause' | 'next' | 'previous' | 'activate' | 'deactivate' - optional source control command; ignored if unsupported by the client
-  - `vad?`: object - optional VAD settings hint
-    - `threshold_db?`: number - signal threshold in dB
-    - `hold_ms?`: integer - hold time in milliseconds
 
-All fields are optional. The server may send any subset (`command`, `control`, and/or `vad`) in one message.
+All fields are optional. The server may send any subset (`command` and/or `control`) in one message.
 
 #### Source command semantics
 
@@ -1299,10 +1296,6 @@ All fields are optional. The server may send any subset (`command`, `control`, a
 - Effective default after handshake is `stop` (ingest inactive).
 - Server ingest interest is represented by `command: "start"` / `command: "stop"`.
 - Server implementations should ignore/drop source binary chunks while ingest is not active.
-
-#### `vad` semantics
-
-`vad` is an optional server hint for source-side line-sense behavior (`threshold_db`, `hold_ms`). It allows centralized tuning and consistent behavior across sources/groups. Clients may ignore unsupported hints.
 
 Example `server/command` to start capture:
 ```json
@@ -1443,14 +1436,6 @@ The `controller` object in [`server/state`](#server--client-serverstate) has thi
   - `supported_commands`: string[] - subset of: 'play' | 'pause' | 'stop' | 'next' | 'previous' | 'volume' | 'mute' | 'repeat_off' | 'repeat_one' | 'repeat_all' | 'shuffle' | 'unshuffle' | 'switch' | 'seek' | 'seek_relative'
   - `volume`: integer - volume of the whole group, range 0-100
   - `muted`: boolean - mute state of the whole group
-  - `sources?`: object[] - list of available/known sources on the server
-    - `id`: string - stable identifier of the source (typically the source `client_id`)
-    - `name`: string - friendly name
-    - `state`: 'idle' | 'streaming' | 'error'
-    - `signal?`: 'unknown' | 'present' | 'absent' - optional line sensing/signal presence
-    - `selected?`: boolean - whether this source is currently selected for this group
-    - `last_event?`: 'started' | 'stopped' - last source event (optional)
-    - `last_event_ts_us?`: integer - server time in microseconds for last event (optional)
   - `repeat`: 'off' | 'one' | 'all' - repeat mode: 'off' = no repeat, 'one' = repeat current track, 'all' = repeat all tracks (in the queue, playlist, etc.)
   - `shuffle`: boolean - shuffle mode enabled/disabled
   - `seek_max_ms?`: integer - maximum absolute position in milliseconds a 'seek' may target (e.g., the end of the current track). The server MUST include this when 'seek' is in `supported_commands`, and MUST omit 'seek' when the seekable range is unknown (e.g., live streams); 'seek_relative' MAY still be offered

--- a/README.md
+++ b/README.md
@@ -1212,8 +1212,8 @@ The `source` object in [`server/command`](#server--client-servercommand) has thi
 #### Source command semantics
 
 - `command` controls whether this source streams to the server:
-  - `start`: server requests the source to begin streaming. The client SHOULD send `input_stream/start` and then send source audio chunks.
-  - `stop`: server requests the source to stop streaming. The client SHOULD send `input_stream/end` and stop sending source audio chunks.
+  - `start`: server requests the source to begin streaming. The client SHOULD send `client_stream/start` and then send source audio chunks.
+  - `stop`: server requests the source to stop streaming. The client SHOULD send `client_stream/end` and stop sending source audio chunks.
 
 #### Default streaming behavior
 
@@ -1221,11 +1221,11 @@ The default after the handshake is `stop`: a source MUST NOT stream until the se
 
 A source that supports line sensing reports `signal` in [`client/state`](#client--server-clientstate). The server MAY use it as a hint for when to send `command: "start"` or `command: "stop"`, but the decision is server policy.
 
-When the server removes `source` from [`active_roles`](#server--client-serveractivate), the client sends `input_stream/end` and stops sending chunks.
+When the server removes `source` from [`active_roles`](#server--client-serveractivate), the client sends `client_stream/end` and stops sending chunks.
 
-### Client → Server: `input_stream/start`
+### Client → Server: `client_stream/start`
 
-The `input_stream/start` message announces the active input stream format and provides any required codec header data.
+The `client_stream/start` message announces the active input stream format and provides any required codec header data.
 
 - `source`: object
   - `codec`: 'opus' | 'flac' | 'pcm'
@@ -1234,14 +1234,14 @@ The `input_stream/start` message announces the active input stream format and pr
   - `bit_depth`: integer
   - `codec_header?`: string - Base64 encoded codec header (if necessary; e.g., FLAC)
 
-### Client → Server: `input_stream/end`
+### Client → Server: `client_stream/end`
 
-The client ends the current input stream. After this message, no more source audio chunks SHOULD be sent until a new `input_stream/start`.
+The client ends the current input stream. After this message, no more source audio chunks SHOULD be sent until a new `client_stream/start`.
 
 ### Client → Server: Source Audio Chunks (Binary)
 
-Binary messages SHOULD be rejected by the server if there is no open input stream (i.e., received before an `input_stream/start` or after an `input_stream/end`).
-Clients MUST send `input_stream/start` before the first audio chunk.
+Binary messages SHOULD be rejected by the server if there is no open input stream (i.e., received before a `client_stream/start` or after a `client_stream/end`).
+Clients MUST send `client_stream/start` before the first audio chunk.
 
 - Byte 0: message type `12` (uint8)
 - Bytes 1-8: timestamp (big-endian int64) - server clock time in microseconds when the first sample was captured

--- a/README.md
+++ b/README.md
@@ -1167,7 +1167,7 @@ The timestamp indicates when the first audio sample in this chunk should be outp
 ## Source messages
 This section describes messages specific to clients with the `source` role, which capture audio from a local input (e.g., AUX/line-in, turntable preamp, Bluetooth receiver, or microphone) and stream it to the server. Unlike other roles, a source sends audio to the server; the server remains the single place that resamples, transcodes, mixes, buffers, and distributes audio to output players. Sources stay simple: they capture and encode audio, optionally report basic signal presence (level or line sensing), and stream timestamped audio frames.
 
-A device may implement both the `source` and `player` roles (e.g., a speaker with a local AUX input forwarded into Sendspin). The server may also expose its own built-in inputs (e.g., a line-in on the server host, or an attached HDMI capture device) as a virtual source client that participates in the same state model as regular source clients.
+A device MAY implement both the `source` and `player` roles (e.g., a speaker with a local AUX input forwarded into Sendspin). The server MAY also expose its own built-in inputs (e.g., a line-in on the server host, or an attached HDMI capture device) as a virtual source client that participates in the same state model as regular source clients.
 
 A source client uses the same clock synchronization mechanism as all clients. Binary source audio messages are timestamped in the server time domain using the clock offset learned from `client/time`/`server/time`.
 
@@ -1187,9 +1187,9 @@ The `source@v1_support` object in [`client/hello`](#client--server-clienthello) 
     - `level?`: boolean - true if source reports `level`
     - `line_sense?`: boolean - true if source reports `signal`
 
-**Note:** Servers must support all audio codecs: 'opus', 'flac', and 'pcm'.
+**Note:** Servers MUST support all audio codecs: 'opus', 'flac', and 'pcm'.
 
-**Note:** Servers should offer only the `supported_formats` options and avoid requesting unsupported formats.
+**Note:** Servers SHOULD offer only the `supported_formats` options and avoid requesting unsupported formats.
 
 Example `client/hello` excerpt:
 ```json
@@ -1255,7 +1255,7 @@ Notifies the server of a capture change initiated at the source rather than by a
 
 - `source`: object
   - `command`: 'started' | 'stopped'
-    - `started`: capture began at the source. A source that [starts ingest on its own](#default-ingest-behavior) sends this with its `input_stream/start`.
+    - `started`: capture began at the source. A source that [starts ingest on its own](#default-ingest-behavior) SHOULD send this with its `input_stream/start`.
     - `stopped`: capture ended at the source.
 
 ### Server → Client: `server/command` source object
@@ -1268,14 +1268,14 @@ The `source` object in [`server/command`](#server--client-servercommand) has thi
 #### Source command semantics
 
 - `command` controls Sendspin ingest lifecycle for this source:
-  - `start`: server requests ingest to become active. The client should transition to `state: "streaming"`, send `input_stream/start`, and then send source audio chunks.
-  - `stop`: server requests ingest to become inactive. The client should send `input_stream/end`, stop sending source audio chunks, and transition to `state: "idle"`.
+  - `start`: server requests ingest to become active. The client SHOULD transition to `state: "streaming"`, send `input_stream/start`, and then send source audio chunks.
+  - `stop`: server requests ingest to become inactive. The client SHOULD send `input_stream/end`, stop sending source audio chunks, and transition to `state: "idle"`.
 
 #### Default ingest behavior
 
 - Effective default after handshake is `stop` (ingest inactive).
 - Server ingest interest is represented by `command: "start"` / `command: "stop"`.
-- Server implementations should ignore/drop source binary chunks while ingest is not active.
+- Server implementations SHOULD ignore/drop source binary chunks while ingest is not active.
 
 A source MAY also start ingest on its own without waiting for `command: "start"`: it transitions to `state: "streaming"`, sends `input_stream/start`, and begins sending chunks. This lets a source that detects local signal (e.g., a turntable starting) begin streaming immediately, with no `signal`-to-`start` round trip. The server decides whether to route or drop the stream per its own policy, and a source MUST still honor a subsequent `command: "stop"`.
 
@@ -1300,7 +1300,7 @@ The `input_stream/start` message announces the active input stream format and pr
   - `channels`: integer
   - `sample_rate`: integer
   - `bit_depth`: integer
-  - `codec_header?`: string - Base64 encoded codec header (required for Opus/FLAC)
+  - `codec_header?`: string - Base64 encoded codec header (REQUIRED for Opus/FLAC)
 
 Example `input_stream/start`:
 ```json
@@ -1320,7 +1320,7 @@ Example `input_stream/start`:
 
 ### Server → Client: `input_stream/request-format`
 
-The server can request a different input stream format. Clients should respond by reconfiguring capture (if supported) and sending a new `input_stream/start` with the updated format and header.
+The server MAY request a different input stream format. Clients SHOULD respond by reconfiguring capture (if supported) and sending a new `input_stream/start` with the updated format and header.
 
 - `source`: object
   - `codec?`: 'opus' | 'flac' | 'pcm'
@@ -1330,20 +1330,20 @@ The server can request a different input stream format. Clients should respond b
 
 ### Client → Server: `input_stream/end`
 
-The client ends the current input stream. After this message, no more source audio chunks should be sent until a new `input_stream/start`.
+The client ends the current input stream. After this message, no more source audio chunks SHOULD be sent until a new `input_stream/start`.
 
 ### Client → Server: Source Audio Chunks (Binary)
 
-Binary messages should be rejected by the server if the source is not in `state: 'streaming'`.
-Clients must send `input_stream/start` before the first audio chunk.
+Binary messages SHOULD be rejected by the server if the source is not in `state: 'streaming'`.
+Clients MUST send `input_stream/start` before the first audio chunk.
 
 - Byte 0: message type `12` (uint8)
 - Bytes 1-8: timestamp (big-endian int64) - server clock time in microseconds when the first sample was captured
 - Rest of bytes: encoded audio frame
 
-The timestamp indicates when the first audio sample in this chunk was captured (in server time domain). The server may resample/transcode and then distribute the audio to players with its normal buffering and synchronization strategy.
+The timestamp indicates when the first audio sample in this chunk was captured (in server time domain). The server MAY resample/transcode and then distribute the audio to players with its normal buffering and synchronization strategy.
 
-**Note:** Source timestamps are derived from the client's clock offset and may show small discontinuities or drift (e.g., ADC clock variance). Server implementations should not assume perfectly continuous timestamps; the audio sample stream itself should remain continuous.
+**Note:** Source timestamps are derived from the client's clock offset and may show small discontinuities or drift (e.g., ADC clock variance). Server implementations SHOULD NOT assume perfectly continuous timestamps; the audio sample stream itself SHOULD remain continuous.
 
 ## Controller messages
 This section describes messages specific to clients with the `controller` role, which enables the client to control the Sendspin group this client is part of, and switch between groups.

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ Sendspin is a multi-room music experience protocol. The goal of the protocol is 
 ## Definitions
 
 - **Sendspin Server** - orchestrates all devices, generates audio streams, manages players and clients, provides metadata
-- **Sendspin Client** - a client that can play audio, visualize audio, display metadata, display colors, or provide music controls. Has different possible roles (player, metadata, controller, artwork, visualizer, color). Every client has a unique identifier
+- **Sendspin Client** - a client that can play audio, capture audio inputs, visualize audio, display metadata, display colors, or provide music controls. Has different possible roles (player, source, metadata, controller, artwork, visualizer, color). Every client has a unique identifier
   - **Player** - receives audio and plays it in sync. Has its own volume and mute state and preferred format settings
+  - **Source** - captures audio from a local input and streams it to the server
   - **Controller** - controls the Sendspin group this client is part of
   - **Metadata** - displays text metadata (title, artist, album, etc.)
   - **Artwork** - displays artwork images. Has preferred format for images
@@ -24,7 +25,7 @@ Sendspin is a multi-room music experience protocol. The goal of the protocol is 
 
 Roles define what capabilities and responsibilities a client has. All roles use explicit versioning with the `@` character: `<role>@<version>` (e.g., `player@v1`, `controller@v1`).
 
-This specification defines the following roles: [`player`](#player-messages), [`controller`](#controller-messages), [`metadata`](#metadata-messages), [`artwork`](#artwork-messages), [`visualizer`](#visualizer-messages), [`color`](#color-messages). All servers must implement all versions of these roles described in this specification.
+This specification defines the following roles: [`player`](#player-messages), [`source`](#source-messages), [`controller`](#controller-messages), [`metadata`](#metadata-messages), [`artwork`](#artwork-messages), [`visualizer`](#visualizer-messages), [`color`](#color-messages). All servers must implement all versions of these roles described in this specification.
 
 All role names and versions not starting with `_` are reserved for future revisions of this specification.
 
@@ -240,7 +241,7 @@ Binary message IDs typically use **bits 7-2** for role type and **bits 1-0** for
 - `0000001x` (2-3): Used for [Fragmentation](#fragmentation)
 - `000001xx` (4-7): Player role
 - `000010xx` (8-11): Artwork role
-- `000011xx` (12-15): Reserved for a future role
+- `000011xx` (12-15): Source role
 - `00010xxx` (16-23): Visualizer role
 - Roles 6-47 (IDs 24-191): Reserved for future roles
 - Roles 48-63 (IDs 192-255): Available for use by [application-specific roles](#application-specific-roles)
@@ -431,12 +432,14 @@ Players that can output audio should have the role `player`.
 - `trust_level`: 'user' | 'none' - the [trust level](#definitions) the client extends to this server, governing which operations the server may issue. `'user'` reflects a pairing record for this server; `'none'` is sent in [pairing](#pairing) handshakes and on [unpaired access](#unpaired-access), where no record exists for this server
 - `supported_roles`: string[] - versioned roles supported by the client (e.g., `player@v1`, `controller@v1`). Defined versioned roles are:
   - `player@v1` - outputs audio
+  - `source@v1` - captures audio from a local input and streams it to the server
   - `controller@v1` - controls the current Sendspin group
   - `metadata@v1` - displays text metadata describing the currently playing audio
   - `artwork@v1` - displays artwork images
   - `visualizer@v1` - visualizes audio
   - `color@v1` - receives colors derived from the current audio
 - `player@v1_support?`: object - only if `player@v1` is listed ([see player@v1 support object details](#client--server-clienthello-playerv1-support-object))
+- `source@v1_support?`: object - only if `source@v1` is listed ([see source@v1 support object details](#client--server-clienthello-sourcev1-support-object))
 - `artwork@v1_support?`: object - only if `artwork@v1` is listed ([see artwork@v1 support object details](#client--server-clienthello-artworkv1-support-object))
 - `visualizer@v1_support?`: object - only if `visualizer@v1` is listed ([see visualizer@v1 support object details](#client--server-clienthello-visualizerv1-support-object))
 - `supported_pair_methods?`: object[] - pairing methods this client offers, each described by a [pair-method descriptor](#client--server-clienthello-pair-method-descriptor).
@@ -511,6 +514,7 @@ The initial message MUST include all state fields. In subsequent messages, the c
   - `'error'` - client has a problem preventing normal operation (unable to keep up, clock sync issues, etc.)
   - `'external_source'` - client is in use by an external system and is not currently participating in Sendspin playback with this server. See [External Source Handling](#external-source-handling)
 - `player?`: object - only if client has `player` role ([see player state object details](#client--server-clientstate-player-object))
+- `source?`: object - only if client has `source` role ([see source state object details](#client--server-clientstate-source-object))
 
 [Application-specific roles](#application-specific-roles) may also include objects in this message (keys starting with `_`).
 
@@ -534,6 +538,7 @@ If the client is already in a solo group:
 Client sends commands to the server. Contains command objects based on the client's supported roles.
 
 - `controller?`: object - only if client has `controller` role ([see controller command object details](#client--server-clientcommand-controller-object))
+- `source?`: object - only if client has `source` role ([see source command object details](#client--server-clientcommand-source-object))
 
 [Application-specific roles](#application-specific-roles) may also include objects in this message (keys starting with `_`).
 
@@ -554,6 +559,7 @@ Only include fields that have changed. The client will merge these updates into 
 Server sends commands to the client. Contains role-specific command objects.
 
 - `player?`: object - only sent to clients with `player` role ([see player command object details](#server--client-servercommand-player-object))
+- `source?`: object - only sent to clients with `source` role ([see source command object details](#server--client-servercommand-source-object))
 
 [Application-specific roles](#application-specific-roles) may also include objects in this message (keys starting with `_`).
 
@@ -1437,14 +1443,14 @@ The `controller` object in [`server/state`](#server--client-serverstate) has thi
   - `supported_commands`: string[] - subset of: 'play' | 'pause' | 'stop' | 'next' | 'previous' | 'volume' | 'mute' | 'repeat_off' | 'repeat_one' | 'repeat_all' | 'shuffle' | 'unshuffle' | 'switch' | 'seek' | 'seek_relative'
   - `volume`: integer - volume of the whole group, range 0-100
   - `muted`: boolean - mute state of the whole group
-  - sources?: object[] - list of available/known sources on the server
-    - id: string - stable identifier of the source (typically the source client_id)
-    - name: string - friendly name
-    - state: 'idle' | 'streaming' | 'error'
-    - signal?: 'unknown' | 'present' | 'absent' - optional line sensing/signal presence
-    - selected?: boolean - whether this source is currently selected for this group
-    - last_event?: 'started' | 'stopped' - last source event (optional)
-    - last_event_ts_us?: integer - server time in microseconds for last event (optional)
+  - `sources?`: object[] - list of available/known sources on the server
+    - `id`: string - stable identifier of the source (typically the source `client_id`)
+    - `name`: string - friendly name
+    - `state`: 'idle' | 'streaming' | 'error'
+    - `signal?`: 'unknown' | 'present' | 'absent' - optional line sensing/signal presence
+    - `selected?`: boolean - whether this source is currently selected for this group
+    - `last_event?`: 'started' | 'stopped' - last source event (optional)
+    - `last_event_ts_us?`: integer - server time in microseconds for last event (optional)
   - `repeat`: 'off' | 'one' | 'all' - repeat mode: 'off' = no repeat, 'one' = repeat current track, 'all' = repeat all tracks (in the queue, playlist, etc.)
   - `shuffle`: boolean - shuffle mode enabled/disabled
   - `seek_max_ms?`: integer - maximum absolute position in milliseconds a 'seek' may target (e.g., the end of the current track). The server MUST include this when 'seek' is in `supported_commands`, and MUST omit 'seek' when the seekable range is unknown (e.g., live streams); 'seek_relative' MAY still be offered

--- a/README.md
+++ b/README.md
@@ -1158,6 +1158,212 @@ Binary messages should be rejected if there is no active stream.
 
 The timestamp indicates when the first audio sample in this chunk should be output. Clients must translate this server timestamp to their local clock using the offset computed from clock synchronization, subtracting their [`static_delay_ms`](#client--server-clientstate-player-object) from the timestamp. Clients should compensate for any known processing delays (e.g., DAC latency, audio buffer delays, amplifier delays) by accounting for these delays when submitting audio to the hardware.
 
+## Sources
+
+Sendspin can also represent **audio inputs** (e.g., AUX/line-in, turntable preamp, Bluetooth receiver, microphone/voice satellite) as first-class, selectable **sources**.
+
+A **source** is implemented as a Sendspin client role that streams audio **to** the server. The server remains the single place that performs heavy work such as resampling, transcoding, equalization, mixing, buffering, visualization and distribution to output players.
+
+Sources are intended to be simple:
+- capture/encode audio
+- optionally provide basic signal presence information (level / line sensing)
+- stream audio frames with timestamps
+
+A device may implement both `source` and `player` roles (e.g., a speaker with a local AUX input that can be forwarded into Sendspin).
+
+The server may also expose **built-in inputs** (e.g., a line-in on the server host, or an HDMI capture device connected to the server) as a **virtual source client**. Virtual sources participate in the same source selection and state model as regular source clients and appear in the controller `sources` list.
+
+## Source messages
+
+This section describes messages specific to clients with the `source` role, which capture audio from a local input and stream it to the server.
+
+A source client uses the same clock synchronization mechanism as all clients. Binary source audio messages are timestamped in the **server time domain** using the clock offset learned from `client/time`/`server/time`.
+
+### Client → Server: `client/hello` source@v1 support object
+
+The `source@v1_support` object in [`client/hello`](#client--server-clienthello) has this structure:
+
+- `source@v1_support`: object
+  - `supported_formats`: object[] - list of supported capture/encode formats in priority order (first is preferred)
+    - `codec`: 'opus' | 'flac' | 'pcm' - codec identifier
+    - `channels`: integer - number of channels (e.g., 1 = mono, 2 = stereo)
+    - `sample_rate`: integer - sample rate in Hz (e.g., 44100, 48000)
+    - `bit_depth`: integer - bit depth (e.g., 16, 24)
+  - `controls?`: string[] - optional source control commands supported by this client (subset of: 'play' | 'pause' | 'next' | 'previous' | 'activate' | 'deactivate')
+  - `features?`: object - optional feature hints
+    - `level?`: boolean - true if source reports `level`
+    - `line_sense?`: boolean - true if source reports `signal`
+
+**Note:** Servers must support all audio codecs: 'opus', 'flac', and 'pcm'.
+**Note:** Servers should offer only the `supported_formats` options and avoid requesting unsupported formats.
+
+Example `client/hello` excerpt:
+```json
+{
+  "type": "client/hello",
+  "payload": {
+    "client_id": "kitchen-linein",
+    "name": "Kitchen Line-In",
+    "version": 1,
+    "supported_roles": ["source@v1"],
+    "source@v1_support": {
+      "supported_formats": [
+        {
+          "codec": "opus",
+          "channels": 2,
+          "sample_rate": 48000,
+          "bit_depth": 16
+        },
+        {
+          "codec": "pcm",
+          "channels": 2,
+          "sample_rate": 48000,
+          "bit_depth": 16
+        }
+      ],
+      "controls": ["play", "pause", "next", "previous", "activate", "deactivate"],
+      "features": {
+        "line_sense": true,
+        "level": true
+      }
+    }
+  }
+}
+```
+
+### Client → Server: `client/state` source object
+
+The `source` object in [`client/state`](#client--server-clientstate) has this structure:
+
+- `source`: object
+  - `state`: 'idle' | 'streaming' | 'error'
+  - `level?`: number - optional normalized RMS/peak level (0.0-1.0), only if 'level' is supported
+  - `signal?`: 'unknown' | 'present' | 'absent' - optional line sensing/signal presence, only if 'line_sense' is supported
+
+Example `client/state` excerpt:
+```json
+{
+  "type": "client/state",
+  "payload": {
+    "source": {
+      "state": "streaming",
+      "signal": "present",
+      "level": 0.42
+    }
+  }
+}
+```
+
+### Client → Server: `client/command` source object
+
+Source clients may send commands to inform the server about user-initiated capture actions (implementation-defined).
+
+- `source`: object
+  - `command`: 'started' | 'stopped'
+
+### Server → Client: `server/command` source object
+
+The `source` object in [`server/command`](#server--client-servercommand) has this structure:
+
+- `source`: object
+  - `command?`: 'start' | 'stop'
+  - `control?`: 'play' | 'pause' | 'next' | 'previous' | 'activate' | 'deactivate' - optional source control command; ignored if unsupported by the client
+  - `vad?`: object - optional VAD settings hint
+    - `threshold_db?`: number - signal threshold in dB
+    - `hold_ms?`: integer - hold time in milliseconds
+
+All fields are optional. The server may send any subset (`command`, `control`, and/or `vad`) in one message.
+
+#### Source command semantics
+
+- `command` controls Sendspin ingest lifecycle for this source:
+  - `start`: server requests ingest to become active. The client should transition to `state: "streaming"`, send `input_stream/start`, and then send source audio chunks.
+  - `stop`: server requests ingest to become inactive. The client should send `input_stream/end`, stop sending source audio chunks, and transition to `state: "idle"`.
+- `control` is optional upstream-device control intent and only applies when advertised in `source@v1_support.controls`.
+  - `play` | `pause` | `next` | `previous`: control content playback behavior on the upstream source device (if supported).
+  - `activate` | `deactivate`: prepare or power-manage the upstream source path (for example power on/off, wake/sleep, input enable/disable).
+
+`start`/`stop` and `play`/`pause` are independent:
+
+- `start`/`stop` govern whether Sendspin ingest is active.
+- `play`/`pause` govern upstream content playback behavior.
+
+#### Default ingest behavior
+
+- Effective default after handshake is `stop` (ingest inactive).
+- Server ingest interest is represented by `command: "start"` / `command: "stop"`.
+- Server implementations should ignore/drop source binary chunks while ingest is not active.
+
+#### `vad` semantics
+
+`vad` is an optional server hint for source-side line-sense behavior (`threshold_db`, `hold_ms`). It allows centralized tuning and consistent behavior across sources/groups. Clients may ignore unsupported hints.
+
+Example `server/command` to start capture:
+```json
+{
+  "type": "server/command",
+  "payload": {
+    "source": {
+      "command": "start"
+    }
+  }
+}
+```
+
+### Client → Server: `input_stream/start`
+
+The `input_stream/start` message announces the active input stream format and provides any required codec header data.
+
+- `source`: object
+  - `codec`: 'opus' | 'flac' | 'pcm'
+  - `channels`: integer
+  - `sample_rate`: integer
+  - `bit_depth`: integer
+  - `codec_header?`: string - Base64 encoded codec header (required for Opus/FLAC)
+
+Example `input_stream/start`:
+```json
+{
+  "type": "input_stream/start",
+  "payload": {
+    "source": {
+      "codec": "flac",
+      "channels": 2,
+      "sample_rate": 48000,
+      "bit_depth": 16,
+      "codec_header": "BASE64..."
+    }
+  }
+}
+```
+
+### Server → Client: `input_stream/request-format`
+
+The server can request a different input stream format. Clients should respond by reconfiguring capture (if supported) and sending a new `input_stream/start` with the updated format and header.
+
+- `source`: object
+  - `codec?`: 'opus' | 'flac' | 'pcm'
+  - `channels?`: integer
+  - `sample_rate?`: integer
+  - `bit_depth?`: integer
+
+### Client → Server: `input_stream/end`
+
+The client ends the current input stream. After this message, no more source audio chunks should be sent until a new `input_stream/start`.
+
+### Client → Server: Source Audio Chunks (Binary)
+
+Binary messages should be rejected by the server if the source is not in `state: 'streaming'`.
+Clients must send `input_stream/start` before the first audio chunk.
+
+- Byte 0: message type `12` (uint8)
+- Bytes 1-8: timestamp (big-endian int64) - server clock time in microseconds when the first sample was captured
+- Rest of bytes: encoded audio frame
+
+The timestamp indicates when the first audio sample in this chunk was captured (in server time domain). The server may resample/transcode and then distribute the audio to players with its normal buffering and synchronization strategy.
+
+**Note:** Source timestamps are derived from the client's clock offset and may show small discontinuities or drift (e.g., ADC clock variance). Server implementations should not assume perfectly continuous timestamps; the audio sample stream itself should remain continuous.
+
 ## Controller messages
 This section describes messages specific to clients with the `controller` role, which enables the client to control the Sendspin group this client is part of, and switch between groups.
 
@@ -1231,6 +1437,14 @@ The `controller` object in [`server/state`](#server--client-serverstate) has thi
   - `supported_commands`: string[] - subset of: 'play' | 'pause' | 'stop' | 'next' | 'previous' | 'volume' | 'mute' | 'repeat_off' | 'repeat_one' | 'repeat_all' | 'shuffle' | 'unshuffle' | 'switch' | 'seek' | 'seek_relative'
   - `volume`: integer - volume of the whole group, range 0-100
   - `muted`: boolean - mute state of the whole group
+  - sources?: object[] - list of available/known sources on the server
+    - id: string - stable identifier of the source (typically the source client_id)
+    - name: string - friendly name
+    - state: 'idle' | 'streaming' | 'error'
+    - signal?: 'unknown' | 'present' | 'absent' - optional line sensing/signal presence
+    - selected?: boolean - whether this source is currently selected for this group
+    - last_event?: 'started' | 'stopped' - last source event (optional)
+    - last_event_ts_us?: integer - server time in microseconds for last event (optional)
   - `repeat`: 'off' | 'one' | 'all' - repeat mode: 'off' = no repeat, 'one' = repeat current track, 'all' = repeat all tracks (in the queue, playlist, etc.)
   - `shuffle`: boolean - shuffle mode enabled/disabled
   - `seek_max_ms?`: integer - maximum absolute position in milliseconds a 'seek' may target (e.g., the end of the current track). The server MUST include this when 'seek' is in `supported_commands`, and MUST omit 'seek' when the seekable range is unknown (e.g., live streams); 'seek_relative' MAY still be offered

--- a/README.md
+++ b/README.md
@@ -1164,26 +1164,12 @@ Binary messages should be rejected if there is no active stream.
 
 The timestamp indicates when the first audio sample in this chunk should be output. Clients must translate this server timestamp to their local clock using the offset computed from clock synchronization, subtracting their [`static_delay_ms`](#client--server-clientstate-player-object) from the timestamp. Clients should compensate for any known processing delays (e.g., DAC latency, audio buffer delays, amplifier delays) by accounting for these delays when submitting audio to the hardware.
 
-## Sources
-
-Sendspin can also represent **audio inputs** (e.g., AUX/line-in, turntable preamp, Bluetooth receiver, microphone/voice satellite) as first-class, selectable **sources**.
-
-A **source** is implemented as a Sendspin client role that streams audio **to** the server. The server remains the single place that performs heavy work such as resampling, transcoding, equalization, mixing, buffering, visualization and distribution to output players.
-
-Sources are intended to be simple:
-- capture/encode audio
-- optionally provide basic signal presence information (level / line sensing)
-- stream audio frames with timestamps
-
-A device may implement both `source` and `player` roles (e.g., a speaker with a local AUX input that can be forwarded into Sendspin).
-
-The server may also expose **built-in inputs** (e.g., a line-in on the server host, or an HDMI capture device connected to the server) as a **virtual source client**. Virtual sources participate in the same source selection and state model as regular source clients.
-
 ## Source messages
+This section describes messages specific to clients with the `source` role, which capture audio from a local input (e.g., AUX/line-in, turntable preamp, Bluetooth receiver, or microphone) and stream it to the server. Unlike other roles, a source sends audio to the server; the server remains the single place that resamples, transcodes, mixes, buffers, and distributes audio to output players. Sources stay simple: they capture and encode audio, optionally report basic signal presence (level or line sensing), and stream timestamped audio frames.
 
-This section describes messages specific to clients with the `source` role, which capture audio from a local input and stream it to the server.
+A device may implement both the `source` and `player` roles (e.g., a speaker with a local AUX input forwarded into Sendspin). The server may also expose its own built-in inputs (e.g., a line-in on the server host, or an attached HDMI capture device) as a virtual source client that participates in the same state model as regular source clients.
 
-A source client uses the same clock synchronization mechanism as all clients. Binary source audio messages are timestamped in the **server time domain** using the clock offset learned from `client/time`/`server/time`.
+A source client uses the same clock synchronization mechanism as all clients. Binary source audio messages are timestamped in the server time domain using the clock offset learned from `client/time`/`server/time`.
 
 **Pairing required:** A source streams captured audio (potentially from a microphone or line-in) to the server, so it MUST only run on a paired connection ([trust level](#definitions) `user`). Servers MUST NOT activate `source@v1` over [unpaired access](#unpaired-access), and a source client MUST refuse to stream when the connection's trust level is `none`.
 
@@ -1202,6 +1188,7 @@ The `source@v1_support` object in [`client/hello`](#client--server-clienthello) 
     - `line_sense?`: boolean - true if source reports `signal`
 
 **Note:** Servers must support all audio codecs: 'opus', 'flac', and 'pcm'.
+
 **Note:** Servers should offer only the `supported_formats` options and avoid requesting unsupported formats.
 
 Example `client/hello` excerpt:
@@ -1228,7 +1215,6 @@ Example `client/hello` excerpt:
           "bit_depth": 16
         }
       ],
-      "controls": ["play", "pause", "next", "previous", "activate", "deactivate"],
       "features": {
         "line_sense": true,
         "level": true

--- a/README.md
+++ b/README.md
@@ -1249,10 +1249,14 @@ Example `client/state` excerpt:
 
 ### Client → Server: `client/command` source object
 
-Source clients may send commands to inform the server about user-initiated capture actions (implementation-defined).
+The `source` object in [`client/command`](#client--server-clientcommand) has this structure:
+
+Notifies the server of a capture change initiated at the source rather than by a server [`command`](#server--client-servercommand-source-object), so the server can apply its own ingest policy (for example, switching playback to a source that just started).
 
 - `source`: object
   - `command`: 'started' | 'stopped'
+    - `started`: capture began at the source. A source that [starts ingest on its own](#default-ingest-behavior) sends this with its `input_stream/start`.
+    - `stopped`: capture ended at the source.
 
 ### Server → Client: `server/command` source object
 

--- a/README.md
+++ b/README.md
@@ -1211,12 +1211,9 @@ The `source` object in [`server/command`](#server--client-servercommand) has thi
 
 #### Default streaming behavior
 
-- Effective default after handshake is `stop` (not streaming).
-- The server signals whether it wants this source's audio with `command: "start"` / `command: "stop"`.
+The default after the handshake is `stop`: a source MUST NOT stream until the server sends `command: "start"`. The server is the only party that initiates streaming.
 
-A source MAY also start streaming on its own without waiting for `command: "start"`: it sends `input_stream/start` and begins sending chunks. This lets a source that detects local signal (e.g., a turntable starting) begin streaming immediately, with no `signal`-to-`start` round trip. The server infers a source-initiated start from the `input_stream/start` it did not request, decides whether to route or drop the stream per its own policy, and a source MUST still honor a subsequent `command: "stop"`.
-
-A source MAY likewise stop on its own (e.g., the input goes silent): it sends `input_stream/end` and stops sending chunks.
+A source that supports line sensing reports `signal` in [`client/state`](#client--server-clientstate). The server MAY use it as a hint for when to send `command: "start"` or `command: "stop"`, but the decision is server policy.
 
 When the server removes `source` from [`active_roles`](#server--client-serveractivate), the client sends `input_stream/end` and stops sending chunks.
 

--- a/README.md
+++ b/README.md
@@ -1214,9 +1214,10 @@ The `source` object in [`server/command`](#server--client-servercommand) has thi
 
 - Effective default after handshake is `stop` (ingest inactive).
 - Server ingest interest is represented by `command: "start"` / `command: "stop"`.
-- Server implementations SHOULD ignore/drop source binary chunks while ingest is not active.
 
 A source MAY also start ingest on its own without waiting for `command: "start"`: it transitions to `state: "streaming"`, sends `input_stream/start`, and begins sending chunks. This lets a source that detects local signal (e.g., a turntable starting) begin streaming immediately, with no `signal`-to-`start` round trip. The server infers a source-initiated start from the `input_stream/start` it did not request, decides whether to route or drop the stream per its own policy, and a source MUST still honor a subsequent `command: "stop"`.
+
+A source MAY likewise stop on its own (e.g., the input goes silent): it sends `input_stream/end`, stops sending chunks, and reports `state: "idle"`.
 
 When the server removes `source` from [`active_roles`](#server--client-serveractivate), the client sends `input_stream/end` and stops sending chunks.
 
@@ -1237,7 +1238,7 @@ The client ends the current input stream. After this message, no more source aud
 
 ### Client → Server: Source Audio Chunks (Binary)
 
-Binary messages SHOULD be rejected by the server if the source is not in `state: 'streaming'`.
+Binary messages SHOULD be rejected by the server if there is no open input stream (i.e., received before an `input_stream/start` or after an `input_stream/end`).
 Clients MUST send `input_stream/start` before the first audio chunk.
 
 - Byte 0: message type `12` (uint8)

--- a/README.md
+++ b/README.md
@@ -538,7 +538,6 @@ If the client is already in a solo group:
 Client sends commands to the server. Contains command objects based on the client's supported roles.
 
 - `controller?`: object - only if client has `controller` role ([see controller command object details](#client--server-clientcommand-controller-object))
-- `source?`: object - only if client has `source` role ([see source command object details](#client--server-clientcommand-source-object))
 
 [Application-specific roles](#application-specific-roles) may also include objects in this message (keys starting with `_`).
 
@@ -1165,11 +1164,13 @@ Binary messages should be rejected if there is no active stream.
 The timestamp indicates when the first audio sample in this chunk should be output. Clients must translate this server timestamp to their local clock using the offset computed from clock synchronization, subtracting their [`static_delay_ms`](#client--server-clientstate-player-object) from the timestamp. Clients should compensate for any known processing delays (e.g., DAC latency, audio buffer delays, amplifier delays) by accounting for these delays when submitting audio to the hardware.
 
 ## Source messages
-This section describes messages specific to clients with the `source` role, which capture audio from a local input (e.g., AUX/line-in, turntable preamp, Bluetooth receiver, or microphone) and stream it to the server. Unlike other roles, a source sends audio to the server; the server remains the single place that resamples, transcodes, mixes, buffers, and distributes audio to output players. Sources stay simple: they capture and encode audio, optionally report basic signal presence (level or line sensing), and stream timestamped audio frames.
+This section describes messages specific to clients with the `source` role, which capture audio from a local input (e.g., AUX/line-in, turntable preamp, Bluetooth receiver, or microphone) and stream it to the server. Unlike other roles, a source sends audio to the server; the server remains the single place that resamples, transcodes, mixes, buffers, and distributes audio to output players. Sources stay simple: they capture and encode audio, optionally report basic signal presence (line sensing), and stream timestamped audio frames.
 
-A device MAY implement both the `source` and `player` roles (e.g., a speaker with a local AUX input forwarded into Sendspin). The server MAY also expose its own built-in inputs (e.g., a line-in on the server host, or an attached HDMI capture device) as a virtual source client that participates in the same state model as regular source clients.
+A device MAY implement both the `source` and `player` roles (e.g., a speaker with a local AUX input forwarded into Sendspin).
 
-A source client uses the same clock synchronization mechanism as all clients. Binary source audio messages are timestamped in the server time domain using the clock offset learned from `client/time`/`server/time`.
+**Note:** The `source` role (capturing input *into* Sendspin) is distinct from the client-level [`state: 'external_source'`](#external-source-handling), which marks a client whose *output* has been taken over by a non-Sendspin system.
+
+A source client uses the same [clock synchronization](#clock-synchronization) mechanism as all clients. Binary source audio messages are timestamped in the server time domain by converting the local capture time with the offset the time filter tracks.
 
 **Pairing required:** A source streams captured audio (potentially from a microphone or line-in) to the server, so it MUST only run on a paired connection ([trust level](#definitions) `user`). Servers MUST NOT activate `source@v1` over [unpaired access](#unpaired-access), and a source client MUST refuse to stream when the connection's trust level is `none`.
 
@@ -1184,86 +1185,24 @@ The `source@v1_support` object in [`client/hello`](#client--server-clienthello) 
     - `sample_rate`: integer - sample rate in Hz (e.g., 44100, 48000)
     - `bit_depth`: integer - bit depth (e.g., 16, 24)
   - `features?`: object - optional feature hints
-    - `level?`: boolean - true if source reports `level`
     - `line_sense?`: boolean - true if source reports `signal`
 
 **Note:** Servers MUST support all audio codecs: 'opus', 'flac', and 'pcm'.
-
-**Note:** Servers SHOULD offer only the `supported_formats` options and avoid requesting unsupported formats.
-
-Example `client/hello` excerpt:
-```json
-{
-  "type": "client/hello",
-  "payload": {
-    "client_id": "kitchen-linein",
-    "name": "Kitchen Line-In",
-    "version": 1,
-    "supported_roles": ["source@v1"],
-    "source@v1_support": {
-      "supported_formats": [
-        {
-          "codec": "opus",
-          "channels": 2,
-          "sample_rate": 48000,
-          "bit_depth": 16
-        },
-        {
-          "codec": "pcm",
-          "channels": 2,
-          "sample_rate": 48000,
-          "bit_depth": 16
-        }
-      ],
-      "features": {
-        "line_sense": true,
-        "level": true
-      }
-    }
-  }
-}
-```
 
 ### Client → Server: `client/state` source object
 
 The `source` object in [`client/state`](#client--server-clientstate) has this structure:
 
 - `source`: object
-  - `state`: 'idle' | 'streaming' | 'error'
-  - `level?`: number - optional normalized RMS/peak level (0.0-1.0), only if 'level' is supported
+  - `state`: 'idle' | 'streaming' - whether the source is currently capturing and sending audio
   - `signal?`: 'present' | 'absent' - optional line sensing/signal presence, only if 'line_sense' is supported
-
-Example `client/state` excerpt:
-```json
-{
-  "type": "client/state",
-  "payload": {
-    "source": {
-      "state": "streaming",
-      "signal": "present",
-      "level": 0.42
-    }
-  }
-}
-```
-
-### Client → Server: `client/command` source object
-
-The `source` object in [`client/command`](#client--server-clientcommand) has this structure:
-
-Notifies the server of a capture change initiated at the source rather than by a server [`command`](#server--client-servercommand-source-object), so the server can apply its own ingest policy (for example, switching playback to a source that just started).
-
-- `source`: object
-  - `command`: 'started' | 'stopped'
-    - `started`: capture began at the source. A source that [starts ingest on its own](#default-ingest-behavior) SHOULD send this with its `input_stream/start`.
-    - `stopped`: capture ended at the source.
 
 ### Server → Client: `server/command` source object
 
 The `source` object in [`server/command`](#server--client-servercommand) has this structure:
 
 - `source`: object
-  - `command?`: 'start' | 'stop'
+  - `command`: 'start' | 'stop'
 
 #### Source command semantics
 
@@ -1277,19 +1216,9 @@ The `source` object in [`server/command`](#server--client-servercommand) has thi
 - Server ingest interest is represented by `command: "start"` / `command: "stop"`.
 - Server implementations SHOULD ignore/drop source binary chunks while ingest is not active.
 
-A source MAY also start ingest on its own without waiting for `command: "start"`: it transitions to `state: "streaming"`, sends `input_stream/start`, and begins sending chunks. This lets a source that detects local signal (e.g., a turntable starting) begin streaming immediately, with no `signal`-to-`start` round trip. The server decides whether to route or drop the stream per its own policy, and a source MUST still honor a subsequent `command: "stop"`.
+A source MAY also start ingest on its own without waiting for `command: "start"`: it transitions to `state: "streaming"`, sends `input_stream/start`, and begins sending chunks. This lets a source that detects local signal (e.g., a turntable starting) begin streaming immediately, with no `signal`-to-`start` round trip. The server infers a source-initiated start from the `input_stream/start` it did not request, decides whether to route or drop the stream per its own policy, and a source MUST still honor a subsequent `command: "stop"`.
 
-Example `server/command` to start capture:
-```json
-{
-  "type": "server/command",
-  "payload": {
-    "source": {
-      "command": "start"
-    }
-  }
-}
-```
+When the server removes `source` from [`active_roles`](#server--client-serveractivate), the client sends `input_stream/end` and stops sending chunks.
 
 ### Client → Server: `input_stream/start`
 
@@ -1300,33 +1229,7 @@ The `input_stream/start` message announces the active input stream format and pr
   - `channels`: integer
   - `sample_rate`: integer
   - `bit_depth`: integer
-  - `codec_header?`: string - Base64 encoded codec header (REQUIRED for Opus/FLAC)
-
-Example `input_stream/start`:
-```json
-{
-  "type": "input_stream/start",
-  "payload": {
-    "source": {
-      "codec": "flac",
-      "channels": 2,
-      "sample_rate": 48000,
-      "bit_depth": 16,
-      "codec_header": "BASE64..."
-    }
-  }
-}
-```
-
-### Server → Client: `input_stream/request-format`
-
-The server MAY request a different input stream format. Clients SHOULD respond by reconfiguring capture (if supported) and sending a new `input_stream/start` with the updated format and header.
-
-- `source`: object
-  - `codec?`: 'opus' | 'flac' | 'pcm'
-  - `channels?`: integer
-  - `sample_rate?`: integer
-  - `bit_depth?`: integer
+  - `codec_header?`: string - Base64 encoded codec header (if necessary; e.g., FLAC)
 
 ### Client → Server: `input_stream/end`
 
@@ -1343,7 +1246,9 @@ Clients MUST send `input_stream/start` before the first audio chunk.
 
 The timestamp indicates when the first audio sample in this chunk was captured (in server time domain). The server MAY resample/transcode and then distribute the audio to players with its normal buffering and synchronization strategy.
 
-**Note:** Source timestamps are derived from the client's clock offset and may show small discontinuities or drift (e.g., ADC clock variance). Server implementations SHOULD NOT assume perfectly continuous timestamps; the audio sample stream itself SHOULD remain continuous.
+A device that implements both `source` and `player` MUST NOT play its captured input locally. Like every player, it outputs only the stream the server distributes, so its output stays in sync with the rest of the group.
+
+**Note:** Source timestamps are derived from the client's clock offset, which the time filter keeps re-estimating, so they may show discontinuities or drift (e.g., ADC clock variance). Server implementations SHOULD NOT assume perfectly continuous timestamps; the audio sample stream itself SHOULD remain continuous.
 
 ## Controller messages
 This section describes messages specific to clients with the `controller` role, which enables the client to control the Sendspin group this client is part of, and switch between groups.

--- a/README.md
+++ b/README.md
@@ -1195,7 +1195,6 @@ The `source@v1_support` object in [`client/hello`](#client--server-clienthello) 
     - `channels`: integer - number of channels (e.g., 1 = mono, 2 = stereo)
     - `sample_rate`: integer - sample rate in Hz (e.g., 44100, 48000)
     - `bit_depth`: integer - bit depth (e.g., 16, 24)
-  - `controls?`: string[] - optional source control commands supported by this client (subset of: 'play' | 'pause' | 'next' | 'previous')
   - `features?`: object - optional feature hints
     - `level?`: boolean - true if source reports `level`
     - `line_sense?`: boolean - true if source reports `signal`
@@ -1273,22 +1272,12 @@ The `source` object in [`server/command`](#server--client-servercommand) has thi
 
 - `source`: object
   - `command?`: 'start' | 'stop'
-  - `control?`: 'play' | 'pause' | 'next' | 'previous' - optional source control command; ignored if unsupported by the client
-
-All fields are optional. The server may send any subset (`command` and/or `control`) in one message.
 
 #### Source command semantics
 
 - `command` controls Sendspin ingest lifecycle for this source:
   - `start`: server requests ingest to become active. The client should transition to `state: "streaming"`, send `input_stream/start`, and then send source audio chunks.
   - `stop`: server requests ingest to become inactive. The client should send `input_stream/end`, stop sending source audio chunks, and transition to `state: "idle"`.
-- `control` is optional upstream-device control intent and only applies when advertised in `source@v1_support.controls`.
-  - `play` | `pause` | `next` | `previous`: control content playback behavior on the upstream source device (if supported).
-
-`start`/`stop` and `play`/`pause` are independent:
-
-- `start`/`stop` govern whether Sendspin ingest is active.
-- `play`/`pause` govern upstream content playback behavior.
 
 #### Default ingest behavior
 

--- a/README.md
+++ b/README.md
@@ -1195,7 +1195,7 @@ The `source@v1_support` object in [`client/hello`](#client--server-clienthello) 
     - `channels`: integer - number of channels (e.g., 1 = mono, 2 = stereo)
     - `sample_rate`: integer - sample rate in Hz (e.g., 44100, 48000)
     - `bit_depth`: integer - bit depth (e.g., 16, 24)
-  - `controls?`: string[] - optional source control commands supported by this client (subset of: 'play' | 'pause' | 'next' | 'previous' | 'activate' | 'deactivate')
+  - `controls?`: string[] - optional source control commands supported by this client (subset of: 'play' | 'pause' | 'next' | 'previous')
   - `features?`: object - optional feature hints
     - `level?`: boolean - true if source reports `level`
     - `line_sense?`: boolean - true if source reports `signal`
@@ -1273,7 +1273,7 @@ The `source` object in [`server/command`](#server--client-servercommand) has thi
 
 - `source`: object
   - `command?`: 'start' | 'stop'
-  - `control?`: 'play' | 'pause' | 'next' | 'previous' | 'activate' | 'deactivate' - optional source control command; ignored if unsupported by the client
+  - `control?`: 'play' | 'pause' | 'next' | 'previous' - optional source control command; ignored if unsupported by the client
 
 All fields are optional. The server may send any subset (`command` and/or `control`) in one message.
 
@@ -1284,7 +1284,6 @@ All fields are optional. The server may send any subset (`command` and/or `contr
   - `stop`: server requests ingest to become inactive. The client should send `input_stream/end`, stop sending source audio chunks, and transition to `state: "idle"`.
 - `control` is optional upstream-device control intent and only applies when advertised in `source@v1_support.controls`.
   - `play` | `pause` | `next` | `previous`: control content playback behavior on the upstream source device (if supported).
-  - `activate` | `deactivate`: prepare or power-manage the upstream source path (for example power on/off, wake/sleep, input enable/disable).
 
 `start`/`stop` and `play`/`pause` are independent:
 

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ Binary audio messages contain timestamps in the server's time domain indicating 
 
 Each [`server/time`](#server--client-servertime) response provides the four timestamps needed by the filter: the client's transmitted timestamp, the server's received timestamp, the server's transmitted timestamp, and the client's receive time (captured locally when the response arrives). Clients feed these into the time filter via its `update` method and use its `compute_client_time` method to convert server timestamps to local clock values for playback scheduling.
 
-A player MUST NOT report `state: 'synchronized'` until its time filter has converged enough to begin scheduling playback.
+A player MUST NOT report `state: 'synchronized'` until its time filter has converged enough to begin scheduling playback. A source MUST NOT report `state: 'synchronized'` until its time filter has converged enough to timestamp captured audio.
 
 ## Playback Synchronization
 
@@ -554,7 +554,7 @@ Sent once the client is ready to report its operational `state`, and whenever an
 The initial message MUST include all state fields. In subsequent messages, the client MAY send only the fields that have changed; the server MUST merge each update into existing state, retaining the last value of any field that is absent. A client MAY instead resend unchanged fields, up to its full state.
 
 - `state`: 'synchronized' | 'external_source' - operational state of the client
-  - `'synchronized'` - client is operational and ready to participate in playback; for a player this means its clock is synchronized with the server.
+  - `'synchronized'` - client is operational and ready to participate in playback; for a player or source this means its clock is synchronized with the server.
   - `'external_source'` - client is in use by an external system and is not currently participating in Sendspin playback with this server. See [External Source Handling](#external-source-handling)
 - `player?`: object - only if client has `player` role ([see player state object details](#client--server-clientstate-player-object))
 - `source?`: object - only if client has `source` role ([see source state object details](#client--server-clientstate-source-object))
@@ -1290,7 +1290,7 @@ The client ends the current input stream. After this message, no more source aud
 
 ### Client → Server: Source Audio Chunks (Binary)
 
-Binary messages SHOULD be rejected by the server if there is no open input stream (i.e., received before a `client_stream/start` or after a `client_stream/end`).
+Binary messages SHOULD be rejected by the server if there is no open input stream (i.e., received before a `client_stream/start` or after a `client_stream/end`) or the client is not in the `synchronized` [state](#client--server-clientstate).
 Clients MUST send `client_stream/start` before the first audio chunk.
 
 - Byte 0: message type `12` (uint8)


### PR DESCRIPTION
Adds the `source@v1` role that allows a client to capture local audio (line-in, turntable, Bluetooth receiver, microphone) and stream it to the server, while the server stays the single place that resamples, transcodes, mixes, buffers, and distributes to players (including back to the source itself when it is also a player, so it stays in sync).

Heavily based on #52 by @rudyberends but simplified to the core. This PR specifically removes:
- the activation model (input type, activation kind)
- `level` reporting (kept `signal` line-sensing)
- the `client/command` source notifications
- `select_source` controller integration and source listing in `server/state`
- server-side virtual source clients

Also rebases it onto the encryption work (#84), and now requires source clients to be paired since an unpaired source could otherwise inject malformed audio into the server.