### PR TITLE
Require clients to ignore unrecognized fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,8 @@ Cleartext handshake messages (`client/init`, `server/init`, `noise/handshake`) a
 
 All messages have a `type` field identifying the message and a `payload` object containing message-specific data. The payload structure varies by message type and is detailed in each message section below.
 
+**Forward compatibility.** Clients MUST ignore unrecognized `payload` fields (keys not defined for the message) rather than treating them as an error.
+
 Message format example:
 
 ```json


### PR DESCRIPTION
Clients now MUST ignore unrecognized `payload` fields (keys not defined for the message), so later revisions can add fields without breaking older clients.
Unrecognized values are except from this rule.

`sendspin-cpp`, `sendspin-js` and `aiosendspin` already behave this way, this just makes it explicit so implementations stay consistent.