### PR TITLE
Specify the volume to amplitude curve

### DIFF
--- a/README.md
+++ b/README.md
@@ -1106,7 +1106,7 @@ The object always carries `free`; `capacity` and the costs appear additionally o
 ## Player messages
 This section describes messages specific to clients with the `player` role, which handle audio output and synchronized playback. Player clients receive timestamped audio data, manage their own volume and mute state, and can request different audio formats based on their capabilities and current conditions.
 
-**Note:** Volume values (0-100) represent perceived loudness, not linear amplitude (e.g., volume 50 should be perceived as half as loud as volume 100). Players must convert these values to appropriate amplitude for their audio hardware.
+**Note:** Volume values (0-100) represent perceived loudness, not linear amplitude (e.g., volume 50 should be perceived as half as loud as volume 100). Clients SHOULD convert volume to a linear amplitude (the gain applied to samples, where 1.0 is full scale and 0 is silent) as `amplitude = (volume / 100)^1.5`.
 
 ### Client → Server: `client/hello` player@v1 support object
 


### PR DESCRIPTION
Volume is defined as perceived loudness but the spec named no recommended curve. Clients SHOULD now convert volume with `amplitude = (volume / 100)^1.5` (as was already used in many implementations like `sendspin-cpp`, `aiosendspin`, and `sendspin-rs`).

It is deliberately a SHOULD instead of a MUST because desktop clients often use the OS mixer whose exact perceptual curve is opaque or not controllable.

Part of #94.
