### PR TITLE
Clarify group volume algorithm sends only final per-player volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1541,6 +1541,8 @@ Control the group that's playing and switch groups. Only valid from clients with
      - All delta has been successfully applied, or
      - All players are clamped at their volume boundaries
 
+The loop only computes the final per-player volumes; once it completes, the server sends each player a single volume command — intermediate values are never sent.
+
 This ensures that when setting group volume to 100%, all players will reach 100% if possible, and the final group volume matches the requested volume as closely as player boundaries allow.
 
 **Setting group mute:** When setting group mute via the 'mute' command, the server applies the mute state to all players in the group. Group volume changes do not affect any player's `muted` state (see the [player role](#player-messages)).

--- a/roles/controller/v1.md
+++ b/roles/controller/v1.md
@@ -46,6 +46,8 @@ Control the group that's playing and switch groups. Only valid from clients with
      - All delta has been successfully applied, or
      - All players are clamped at their volume boundaries
 
+The loop only computes the final per-player volumes; once it completes, the server sends each player a single volume command — intermediate values are never sent.
+
 This ensures that when setting group volume to 100%, all players will reach 100% if possible, and the final group volume matches the requested volume as closely as player boundaries allow.
 
 **Setting group mute:** When setting group mute via the 'mute' command, the server applies the mute state to all players in the group. Group volume changes do not affect any player's `muted` state (see the [player role](../player/v1.md#player-messages)).


### PR DESCRIPTION
Clarify group volume algorithm sends only final per-player volumes.