### PR TITLE
Fix pairing sequence diagrams failing to render

### DIFF
--- a/README.md
+++ b/README.md
@@ -840,7 +840,7 @@ sequenceDiagram
     participant Client
     participant Server
 
-    Note over Client,Server: Noise handshake completes (Sentinel PSK when unpaired; long-term Sendspin PSK when re-verifying a paired device)
+    Note over Client,Server: Noise handshake completes (Sentinel PSK when unpaired, long-term Sendspin PSK when re-verifying a paired device)
 
     Server->>Client: server/hello (name)
     Client->>Server: client/hello (supported_pair_methods)
@@ -918,7 +918,7 @@ sequenceDiagram
     participant Client
     participant Server
 
-    Note over Client,Server: Noise handshake completes (Sentinel PSK when unpaired; long-term Sendspin PSK when re-verifying a paired device)
+    Note over Client,Server: Noise handshake completes (Sentinel PSK when unpaired, long-term Sendspin PSK when re-verifying a paired device)
 
     Server->>Client: server/hello (name)
     Client->>Server: client/hello (supported_pair_methods)

--- a/pairing.md
+++ b/pairing.md
@@ -114,7 +114,7 @@ sequenceDiagram
     participant Client
     participant Server
 
-    Note over Client,Server: Noise handshake completes (Sentinel PSK when unpaired; long-term Sendspin PSK when re-verifying a paired device)
+    Note over Client,Server: Noise handshake completes (Sentinel PSK when unpaired, long-term Sendspin PSK when re-verifying a paired device)
 
     Server->>Client: server/hello (name)
     Client->>Server: client/hello (supported_pair_methods)
@@ -192,7 +192,7 @@ sequenceDiagram
     participant Client
     participant Server
 
-    Note over Client,Server: Noise handshake completes (Sentinel PSK when unpaired; long-term Sendspin PSK when re-verifying a paired device)
+    Note over Client,Server: Noise handshake completes (Sentinel PSK when unpaired, long-term Sendspin PSK when re-verifying a paired device)
 
     Server->>Client: server/hello (name)
     Client->>Server: client/hello (supported_pair_methods)


### PR DESCRIPTION
The Dynamic PIN and Static PIN pairing flow diagrams both failed with "Syntax error in text" instead of rendering. Mermaid treats `;` as a statement separator in sequence diagrams, so the semicolon in the shared `Note over Client,Server` line truncated the note text and left the remainder of the line unparseable. Replacing it with a comma keeps the sentence identical and lets both diagrams parse.