### PR TITLE
Allow local device controls to clear mute on volume change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1250,7 +1250,7 @@ This section describes messages specific to clients with the `player` role, whic
 
 **Note:** To avoid audible clicks, clients SHOULD apply volume changes over a short ramp.
 
-**Note:** `volume` and `muted` are independent: a volume change (via [`server/command`](#server--client-servercommand), a group volume command, or device controls) MUST NOT clear the mute state.
+**Note:** `volume` and `muted` are independent: a volume change (via [`server/command`](#server--client-servercommand) or a group volume command) MUST NOT clear the mute state.
 
 ### Client → Server: `client/hello` player@v1 support object
 

--- a/roles/player/v1.md
+++ b/roles/player/v1.md
@@ -5,7 +5,7 @@ This section describes messages specific to clients with the `player` role, whic
 
 **Note:** To avoid audible clicks, clients SHOULD apply volume changes over a short ramp.
 
-**Note:** `volume` and `muted` are independent: a volume change (via [`server/command`](../../messaging.md#server--client-servercommand), a group volume command, or device controls) MUST NOT clear the mute state.
+**Note:** `volume` and `muted` are independent: a volume change (via [`server/command`](../../messaging.md#server--client-servercommand) or a group volume command) MUST NOT clear the mute state.
 
 ### Client → Server: `client/hello` player@v1 support object
 


### PR DESCRIPTION
Requiring that any volume change preserve `muted` was confusing for a device whose only volume input is hardware buttons: pressing volume-up while muted would have to raise the volume and leave it silent. The note now covers only `server/command` and group volume commands, leaving local controls up to the device.

Not a breaking change since this PR just removes requirements.