### PR TITLE
docs: record the editorial rules in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,7 @@ to intra-page anchors at build time.
 The source files follow these rules. Check a change against them before proposing it; reviewers point to them instead of re-explaining.
 
 - **Each role file is self-contained.** A reader who implements one role must not need to read another role file. Text that applies to more than one role therefore appears more than once - the PCM encoding convention and codec framing rules, for example, appear in both `roles/player/v1.md` and `roles/source/v1.md`. Do not combine such text into a shared section.
+- **A client describes itself across `client/hello` and `client/state`.** A field expected to change during a connection belongs in `client/state`; a field expected to stay constant for the connection, such as device identity or a fixed hardware limit, belongs in `client/hello`. `client/hello` is sent once per connection, so a field placed there can only be updated by reconnecting.
 - **Edit the source files, never `README.md`.** `README.md` is generated; the pre-commit hook regenerates it and blocks direct edits.
 - **Every heading needs a unique anchor.** The build fails on two headings that produce the same anchor, and on a link to an anchor with no matching heading.
 - **Use one canonical name per term.** Where the Definitions section defines a term, body text uses exactly that name - not a synonym or a prefixed variant. Prose names agree with the wire identifiers they describe.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,16 @@ Cross-file Markdown links are written file-relative (e.g. `pairing.md#pairing`
 from a top-level file, `../../messaging.md#...` from a role file) and rewritten
 to intra-page anchors at build time.
 
+## Editorial rules
+
+The source files follow these rules. Check a change against them before proposing it; reviewers point to them instead of re-explaining.
+
+- **Each role file is self-contained.** A reader who implements one role must not need to read another role file. Text that applies to more than one role therefore appears more than once - the PCM encoding convention and codec framing rules, for example, appear in both `roles/player/v1.md` and `roles/source/v1.md`. Do not combine such text into a shared section.
+- **Edit the source files, never `README.md`.** `README.md` is generated; the pre-commit hook regenerates it and blocks direct edits.
+- **Every heading needs a unique anchor.** The build fails on two headings that produce the same anchor, and on a link to an anchor with no matching heading.
+- **Use one canonical name per term.** Where the Definitions section defines a term, body text uses exactly that name - not a synonym or a prefixed variant. Prose names agree with the wire identifiers they describe.
+- **`**Note:**` blocks are non-normative.** Requirements - uppercase BCP 14 keywords (MUST, SHOULD, MAY, ...) - belong in body text. A note must read as a comment the reader can skip.
+
 ## Pre-commit hook
 
 A hook keeps `README.md` regenerated in every commit from the sources and blocks accidental

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ The source files follow these rules. Check a change against them before proposin
 - **A client describes itself across `client/hello` and `client/state`.** A field expected to change during a connection belongs in `client/state`; a field expected to stay constant for the connection, such as device identity or a fixed hardware limit, belongs in `client/hello`. `client/hello` is sent once per connection, so a field placed there can only be updated by reconnecting.
 - **Edit the source files, never `README.md`.** `README.md` is generated; the pre-commit hook regenerates it and blocks direct edits.
 - **Every heading needs a unique anchor.** The build fails on two headings that produce the same anchor, and on a link to an anchor with no matching heading.
-- **Use one canonical name per term.** Where the Definitions section defines a term, body text uses exactly that name - not a synonym or a prefixed variant. Prose names agree with the wire identifiers they describe.
+- **Use one canonical name per term.** Where the Definitions section defines a term, body text uses exactly that name - not a synonym or a prefixed variant, unless the prefix disambiguates (`Sendspin client`, where the WebSocket client is a different thing). Prose names agree with the wire identifiers they describe.
 - **`**Note:**` blocks are non-normative.** Requirements - uppercase BCP 14 keywords (MUST, SHOULD, MAY, ...) - belong in body text. A note must read as a comment the reader can skip.
 
 ## Pre-commit hook


### PR DESCRIPTION
Fixes #153.

Adds an **Editorial rules** section to `CONTRIBUTING.md`, placed between the source-files section and the pre-commit hook. Six rules:

1. **Each role file is self-contained** — the issue's rule, with the PCM/codec-framing duplication across `roles/player/v1.md` and `roles/source/v1.md` named explicitly so the duplication stops looking like an error (the #90 trap).
2. **Edit the source files, never `README.md`** — the issue's first example.
3. **Every heading needs a unique anchor** — the issue's second example, stating both build failures (duplicate anchors, dangling links).
4. **Use one canonical name per term** — the issue's third example, extended with "prose names agree with the wire identifiers they describe" per the reasoning in #141/#148, plus the exception #148 kept for prefixes that disambiguate (`Sendspin client` vs the WebSocket client).
5. **`**Note:**` blocks are non-normative** — the mechanical rule from #147: uppercase BCP 14 requirements belong in body text.
6. **A client describes itself across `client/hello` and `client/state`**: @maximmaxim345's rule from the #153 comment, with the boundary set at the connection's lifetime rather than permanence.

Rules 4 and 5 now describe `main` as it stands. Rule 6 does not yet: `supported_commands` sits in both messages until #142 consolidates it.

No source spec file changes; `python3 tools/build-readme.py --check` still passes (CONTRIBUTING.md is not part of the README build).
