### PR TITLE
Letterbox art and remove BMP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1658,10 +1658,10 @@ The `artwork@v1_support` object in [`client/hello`](#client--server-clienthello)
   - `channels`: object[] - list of supported artwork channels (length 1-4), array index is the channel number
     - `source`: 'album' | 'artist' | 'none' - artwork source type
     - `format`: 'jpeg' | 'png' - image format identifier
-    - `media_width`: integer - width in pixels of the delivered image
-    - `media_height`: integer - height in pixels of the delivered image
+    - `width`: integer - width in pixels of the delivered image
+    - `height`: integer - height in pixels of the delivered image
 
-The server MUST deliver each image at exactly the `media_width` by `media_height` declared for the channel. It MUST scale the source image to fit within those dimensions preserving its aspect ratio, MUST pad the remaining area with black, and MUST NOT crop the image.
+The server MUST deliver each image at exactly the `width` by `height` declared for the channel. It MUST scale the source image to fit within those dimensions preserving its aspect ratio, MUST pad the remaining area with black, and MUST NOT crop the image.
 
 **Note:** Clients can support 1-4 independent artwork channels depending on their display capabilities. The channel number is determined by array position: `channels[0]` is channel 0 (binary message type 8), `channels[1]` is channel 1 (binary message type 9), etc.
 
@@ -1681,8 +1681,8 @@ Response when an `artwork` stream is active: [`stream/start`](#server--client-st
   - `channel`: integer - channel number (0-3) corresponding to the channel index declared in the artwork [`client/hello`](#client--server-clienthello-artworkv1-support-object)
   - `source?`: 'album' | 'artist' | 'none' - artwork source type
   - `format?`: 'jpeg' | 'png' - requested image format identifier
-  - `media_width?`: integer - requested width in pixels
-  - `media_height?`: integer - requested height in pixels
+  - `width?`: integer - requested width in pixels
+  - `height?`: integer - requested height in pixels
 
 ### Server → Client: `stream/start` artwork object
 
@@ -1697,7 +1697,7 @@ The `artwork` object in [`stream/start`](#server--client-streamstart) has this s
 
 The `channels` array covers every channel index the client declared in [`artwork@v1_support`](#client--server-clienthello-artworkv1-support-object) in the same order. A channel the server is not streaming is represented as `source: 'none'`.
 
-Each channel's configuration MUST match the client's current capability for that channel: the [`client/hello`](#client--server-clienthello-artworkv1-support-object) declaration, as later modified by the [`stream/request-format`](#client--server-streamrequest-format-artwork-object) changes the server honored. The `source` and `format` MUST match the declaration, and `width`/`height` MUST equal the declared `media_width`/`media_height`.
+Each channel's configuration MUST match the client's current capability for that channel: the [`client/hello`](#client--server-clienthello-artworkv1-support-object) declaration, as later modified by the [`stream/request-format`](#client--server-streamrequest-format-artwork-object) changes the server honored. The `source`, `format`, `width`, and `height` MUST match the declaration.
 
 **Late join:** After an artwork `stream/start` (initial or after a reconnection), the server SHOULD immediately send the current image for each channel whose `source` is not `'none'`, so a client joining mid-track does not stay blank until the next track change.
 

--- a/README.md
+++ b/README.md
@@ -1657,7 +1657,7 @@ The `artwork@v1_support` object in [`client/hello`](#client--server-clienthello)
 - `artwork@v1_support`: object
   - `channels`: object[] - list of supported artwork channels (length 1-4), array index is the channel number
     - `source`: 'album' | 'artist' | 'none' - artwork source type
-    - `format`: 'jpeg' | 'png' | 'bmp' - image format identifier
+    - `format`: 'jpeg' | 'png' - image format identifier
     - `media_width`: integer - width in pixels of the delivered image
     - `media_height`: integer - height in pixels of the delivered image
 
@@ -1667,7 +1667,7 @@ The server MUST deliver each image at exactly the `media_width` by `media_height
 
 **None source:** If a channel has `source` set to `none`, the server will not send any artwork data for that channel. This allows clients to disable and enable specific channels on the fly through [`stream/request-format`](#client--server-streamrequest-format-artwork-object) without needing to re-establish the WebSocket connection (useful for dynamic display layouts).
 
-Servers MUST support all image formats: 'jpeg', 'png', and 'bmp'.
+Servers MUST support 'jpeg' and 'png'.
 
 ### Client → Server: `stream/request-format` artwork object
 
@@ -1680,7 +1680,7 @@ Response when an `artwork` stream is active: [`stream/start`](#server--client-st
 - `artwork`: object
   - `channel`: integer - channel number (0-3) corresponding to the channel index declared in the artwork [`client/hello`](#client--server-clienthello-artworkv1-support-object)
   - `source?`: 'album' | 'artist' | 'none' - artwork source type
-  - `format?`: 'jpeg' | 'png' | 'bmp' - requested image format identifier
+  - `format?`: 'jpeg' | 'png' - requested image format identifier
   - `media_width?`: integer - requested width in pixels
   - `media_height?`: integer - requested height in pixels
 
@@ -1691,7 +1691,7 @@ The `artwork` object in [`stream/start`](#server--client-streamstart) has this s
 - `artwork`: object
   - `channels`: object[] - configuration for each artwork channel, array index is the channel number
     - `source`: 'album' | 'artist' | 'none' - artwork source type
-    - `format`: 'jpeg' | 'png' | 'bmp' - format of the encoded image
+    - `format`: 'jpeg' | 'png' - format of the encoded image
     - `width`: integer - width in pixels of the encoded image
     - `height`: integer - height in pixels of the encoded image
 

--- a/README.md
+++ b/README.md
@@ -1658,10 +1658,10 @@ The `artwork@v1_support` object in [`client/hello`](#client--server-clienthello)
   - `channels`: object[] - list of supported artwork channels (length 1-4), array index is the channel number
     - `source`: 'album' | 'artist' | 'none' - artwork source type
     - `format`: 'jpeg' | 'png' | 'bmp' - image format identifier
-    - `media_width`: integer - max width in pixels
-    - `media_height`: integer - max height in pixels
+    - `media_width`: integer - width in pixels of the delivered image
+    - `media_height`: integer - height in pixels of the delivered image
 
-The server MUST scale images to fit within the specified dimensions while preserving aspect ratio.
+The server MUST deliver each image at exactly the `media_width` by `media_height` declared for the channel. It MUST scale the source image to fit within those dimensions preserving its aspect ratio, MUST pad the remaining area with black, and MUST NOT crop the image.
 
 **Note:** Clients can support 1-4 independent artwork channels depending on their display capabilities. The channel number is determined by array position: `channels[0]` is channel 0 (binary message type 8), `channels[1]` is channel 1 (binary message type 9), etc.
 
@@ -1681,8 +1681,8 @@ Response when an `artwork` stream is active: [`stream/start`](#server--client-st
   - `channel`: integer - channel number (0-3) corresponding to the channel index declared in the artwork [`client/hello`](#client--server-clienthello-artworkv1-support-object)
   - `source?`: 'album' | 'artist' | 'none' - artwork source type
   - `format?`: 'jpeg' | 'png' | 'bmp' - requested image format identifier
-  - `media_width?`: integer - requested max width in pixels
-  - `media_height?`: integer - requested max height in pixels
+  - `media_width?`: integer - requested width in pixels
+  - `media_height?`: integer - requested height in pixels
 
 ### Server → Client: `stream/start` artwork object
 
@@ -1697,7 +1697,7 @@ The `artwork` object in [`stream/start`](#server--client-streamstart) has this s
 
 The `channels` array covers every channel index the client declared in [`artwork@v1_support`](#client--server-clienthello-artworkv1-support-object) in the same order. A channel the server is not streaming is represented as `source: 'none'`.
 
-Each channel's configuration MUST stay within the client's current capability for that channel: the [`client/hello`](#client--server-clienthello-artworkv1-support-object) declaration, as later modified by [`stream/request-format`](#client--server-streamrequest-format-artwork-object). The `source` and `format` MUST match the declaration, and `width`/`height` MUST NOT exceed the declared `media_width`/`media_height`.
+Each channel's configuration MUST match the client's current capability for that channel: the [`client/hello`](#client--server-clienthello-artworkv1-support-object) declaration, as later modified by [`stream/request-format`](#client--server-streamrequest-format-artwork-object). The `source` and `format` MUST match the declaration, and `width`/`height` MUST equal the declared `media_width`/`media_height`.
 
 **Late join:** After an artwork `stream/start` (initial or after a reconnection), the server SHOULD immediately send the current image for each channel whose `source` is not `'none'`, so a client joining mid-track does not stay blank until the next track change.
 

--- a/README.md
+++ b/README.md
@@ -1697,7 +1697,7 @@ The `artwork` object in [`stream/start`](#server--client-streamstart) has this s
 
 The `channels` array covers every channel index the client declared in [`artwork@v1_support`](#client--server-clienthello-artworkv1-support-object) in the same order. A channel the server is not streaming is represented as `source: 'none'`.
 
-Each channel's configuration MUST match the client's current capability for that channel: the [`client/hello`](#client--server-clienthello-artworkv1-support-object) declaration, as later modified by [`stream/request-format`](#client--server-streamrequest-format-artwork-object). The `source` and `format` MUST match the declaration, and `width`/`height` MUST equal the declared `media_width`/`media_height`.
+Each channel's configuration MUST match the client's current capability for that channel: the [`client/hello`](#client--server-clienthello-artworkv1-support-object) declaration, as later modified by the [`stream/request-format`](#client--server-streamrequest-format-artwork-object) changes the server honored. The `source` and `format` MUST match the declaration, and `width`/`height` MUST equal the declared `media_width`/`media_height`.
 
 **Late join:** After an artwork `stream/start` (initial or after a reconnection), the server SHOULD immediately send the current image for each channel whose `source` is not `'none'`, so a client joining mid-track does not stay blank until the next track change.
 

--- a/roles/artwork/v1.md
+++ b/roles/artwork/v1.md
@@ -11,10 +11,10 @@ The `artwork@v1_support` object in [`client/hello`](../../messaging.md#client--s
   - `channels`: object[] - list of supported artwork channels (length 1-4), array index is the channel number
     - `source`: 'album' | 'artist' | 'none' - artwork source type
     - `format`: 'jpeg' | 'png' | 'bmp' - image format identifier
-    - `media_width`: integer - max width in pixels
-    - `media_height`: integer - max height in pixels
+    - `media_width`: integer - width in pixels of the delivered image
+    - `media_height`: integer - height in pixels of the delivered image
 
-The server MUST scale images to fit within the specified dimensions while preserving aspect ratio.
+The server MUST deliver each image at exactly the `media_width` by `media_height` declared for the channel. It MUST scale the source image to fit within those dimensions preserving its aspect ratio, MUST pad the remaining area with black, and MUST NOT crop the image.
 
 **Note:** Clients can support 1-4 independent artwork channels depending on their display capabilities. The channel number is determined by array position: `channels[0]` is channel 0 (binary message type 8), `channels[1]` is channel 1 (binary message type 9), etc.
 
@@ -34,8 +34,8 @@ Response when an `artwork` stream is active: [`stream/start`](../../messaging.md
   - `channel`: integer - channel number (0-3) corresponding to the channel index declared in the artwork [`client/hello`](#client--server-clienthello-artworkv1-support-object)
   - `source?`: 'album' | 'artist' | 'none' - artwork source type
   - `format?`: 'jpeg' | 'png' | 'bmp' - requested image format identifier
-  - `media_width?`: integer - requested max width in pixels
-  - `media_height?`: integer - requested max height in pixels
+  - `media_width?`: integer - requested width in pixels
+  - `media_height?`: integer - requested height in pixels
 
 ### Server → Client: `stream/start` artwork object
 
@@ -50,7 +50,7 @@ The `artwork` object in [`stream/start`](../../messaging.md#server--client-strea
 
 The `channels` array covers every channel index the client declared in [`artwork@v1_support`](#client--server-clienthello-artworkv1-support-object) in the same order. A channel the server is not streaming is represented as `source: 'none'`.
 
-Each channel's configuration MUST stay within the client's current capability for that channel: the [`client/hello`](#client--server-clienthello-artworkv1-support-object) declaration, as later modified by [`stream/request-format`](#client--server-streamrequest-format-artwork-object). The `source` and `format` MUST match the declaration, and `width`/`height` MUST NOT exceed the declared `media_width`/`media_height`.
+Each channel's configuration MUST match the client's current capability for that channel: the [`client/hello`](#client--server-clienthello-artworkv1-support-object) declaration, as later modified by [`stream/request-format`](#client--server-streamrequest-format-artwork-object). The `source` and `format` MUST match the declaration, and `width`/`height` MUST equal the declared `media_width`/`media_height`.
 
 **Late join:** After an artwork `stream/start` (initial or after a reconnection), the server SHOULD immediately send the current image for each channel whose `source` is not `'none'`, so a client joining mid-track does not stay blank until the next track change.
 

--- a/roles/artwork/v1.md
+++ b/roles/artwork/v1.md
@@ -11,10 +11,10 @@ The `artwork@v1_support` object in [`client/hello`](../../messaging.md#client--s
   - `channels`: object[] - list of supported artwork channels (length 1-4), array index is the channel number
     - `source`: 'album' | 'artist' | 'none' - artwork source type
     - `format`: 'jpeg' | 'png' - image format identifier
-    - `media_width`: integer - width in pixels of the delivered image
-    - `media_height`: integer - height in pixels of the delivered image
+    - `width`: integer - width in pixels of the delivered image
+    - `height`: integer - height in pixels of the delivered image
 
-The server MUST deliver each image at exactly the `media_width` by `media_height` declared for the channel. It MUST scale the source image to fit within those dimensions preserving its aspect ratio, MUST pad the remaining area with black, and MUST NOT crop the image.
+The server MUST deliver each image at exactly the `width` by `height` declared for the channel. It MUST scale the source image to fit within those dimensions preserving its aspect ratio, MUST pad the remaining area with black, and MUST NOT crop the image.
 
 **Note:** Clients can support 1-4 independent artwork channels depending on their display capabilities. The channel number is determined by array position: `channels[0]` is channel 0 (binary message type 8), `channels[1]` is channel 1 (binary message type 9), etc.
 
@@ -34,8 +34,8 @@ Response when an `artwork` stream is active: [`stream/start`](../../messaging.md
   - `channel`: integer - channel number (0-3) corresponding to the channel index declared in the artwork [`client/hello`](#client--server-clienthello-artworkv1-support-object)
   - `source?`: 'album' | 'artist' | 'none' - artwork source type
   - `format?`: 'jpeg' | 'png' - requested image format identifier
-  - `media_width?`: integer - requested width in pixels
-  - `media_height?`: integer - requested height in pixels
+  - `width?`: integer - requested width in pixels
+  - `height?`: integer - requested height in pixels
 
 ### Server → Client: `stream/start` artwork object
 
@@ -50,7 +50,7 @@ The `artwork` object in [`stream/start`](../../messaging.md#server--client-strea
 
 The `channels` array covers every channel index the client declared in [`artwork@v1_support`](#client--server-clienthello-artworkv1-support-object) in the same order. A channel the server is not streaming is represented as `source: 'none'`.
 
-Each channel's configuration MUST match the client's current capability for that channel: the [`client/hello`](#client--server-clienthello-artworkv1-support-object) declaration, as later modified by the [`stream/request-format`](#client--server-streamrequest-format-artwork-object) changes the server honored. The `source` and `format` MUST match the declaration, and `width`/`height` MUST equal the declared `media_width`/`media_height`.
+Each channel's configuration MUST match the client's current capability for that channel: the [`client/hello`](#client--server-clienthello-artworkv1-support-object) declaration, as later modified by the [`stream/request-format`](#client--server-streamrequest-format-artwork-object) changes the server honored. The `source`, `format`, `width`, and `height` MUST match the declaration.
 
 **Late join:** After an artwork `stream/start` (initial or after a reconnection), the server SHOULD immediately send the current image for each channel whose `source` is not `'none'`, so a client joining mid-track does not stay blank until the next track change.
 

--- a/roles/artwork/v1.md
+++ b/roles/artwork/v1.md
@@ -10,7 +10,7 @@ The `artwork@v1_support` object in [`client/hello`](../../messaging.md#client--s
 - `artwork@v1_support`: object
   - `channels`: object[] - list of supported artwork channels (length 1-4), array index is the channel number
     - `source`: 'album' | 'artist' | 'none' - artwork source type
-    - `format`: 'jpeg' | 'png' | 'bmp' - image format identifier
+    - `format`: 'jpeg' | 'png' - image format identifier
     - `media_width`: integer - width in pixels of the delivered image
     - `media_height`: integer - height in pixels of the delivered image
 
@@ -20,7 +20,7 @@ The server MUST deliver each image at exactly the `media_width` by `media_height
 
 **None source:** If a channel has `source` set to `none`, the server will not send any artwork data for that channel. This allows clients to disable and enable specific channels on the fly through [`stream/request-format`](#client--server-streamrequest-format-artwork-object) without needing to re-establish the WebSocket connection (useful for dynamic display layouts).
 
-Servers MUST support all image formats: 'jpeg', 'png', and 'bmp'.
+Servers MUST support 'jpeg' and 'png'.
 
 ### Client → Server: `stream/request-format` artwork object
 
@@ -33,7 +33,7 @@ Response when an `artwork` stream is active: [`stream/start`](../../messaging.md
 - `artwork`: object
   - `channel`: integer - channel number (0-3) corresponding to the channel index declared in the artwork [`client/hello`](#client--server-clienthello-artworkv1-support-object)
   - `source?`: 'album' | 'artist' | 'none' - artwork source type
-  - `format?`: 'jpeg' | 'png' | 'bmp' - requested image format identifier
+  - `format?`: 'jpeg' | 'png' - requested image format identifier
   - `media_width?`: integer - requested width in pixels
   - `media_height?`: integer - requested height in pixels
 
@@ -44,7 +44,7 @@ The `artwork` object in [`stream/start`](../../messaging.md#server--client-strea
 - `artwork`: object
   - `channels`: object[] - configuration for each artwork channel, array index is the channel number
     - `source`: 'album' | 'artist' | 'none' - artwork source type
-    - `format`: 'jpeg' | 'png' | 'bmp' - format of the encoded image
+    - `format`: 'jpeg' | 'png' - format of the encoded image
     - `width`: integer - width in pixels of the encoded image
     - `height`: integer - height in pixels of the encoded image
 

--- a/roles/artwork/v1.md
+++ b/roles/artwork/v1.md
@@ -50,7 +50,7 @@ The `artwork` object in [`stream/start`](../../messaging.md#server--client-strea
 
 The `channels` array covers every channel index the client declared in [`artwork@v1_support`](#client--server-clienthello-artworkv1-support-object) in the same order. A channel the server is not streaming is represented as `source: 'none'`.
 
-Each channel's configuration MUST match the client's current capability for that channel: the [`client/hello`](#client--server-clienthello-artworkv1-support-object) declaration, as later modified by [`stream/request-format`](#client--server-streamrequest-format-artwork-object). The `source` and `format` MUST match the declaration, and `width`/`height` MUST equal the declared `media_width`/`media_height`.
+Each channel's configuration MUST match the client's current capability for that channel: the [`client/hello`](#client--server-clienthello-artworkv1-support-object) declaration, as later modified by the [`stream/request-format`](#client--server-streamrequest-format-artwork-object) changes the server honored. The `source` and `format` MUST match the declaration, and `width`/`height` MUST equal the declared `media_width`/`media_height`.
 
 **Late join:** After an artwork `stream/start` (initial or after a reconnection), the server SHOULD immediately send the current image for each channel whose `source` is not `'none'`, so a client joining mid-track does not stay blank until the next track change.
 


### PR DESCRIPTION
The previous artwork scaling rule said the server "will scale images to fit within the specified dimensions while preserving aspect ratio", which reads as fit-inside: a square cover requested at 800x480 would arrive 480x480. The spec will adopt what `aiosendspin` already does: letterbox.

Changes:

- `width`/`height` are the dimensions of the delivered image, not upper bounds (renamed from `media_width` and `media_height`)
- The server MUST pad to those dimensions with black and MUST NOT crop
- `stream/start` `width`/`height` MUST equal the declared `width`/`height` rather than merely not exceeding them
- Drop `'bmp'` from the artwork formats, leaving `'jpeg'` and `'png'` (see comments in #134)

The equality rule settles the case that blocked scheduled artwork updates: with the delivered size pinned to the declaration, a later image cannot arrive at a different aspect ratio than the resolution `stream/start` announced.

I'll make a future PR splitting large images across messages, the remaining part of #134.

Closes #128

## Breaking Changes
- BMP is now unsupported
- `media_width`/`media_height` are renamed to `width`/`height`
- Servers must letterbox artwork