### PR TITLE
Drop unpaired-access shipping default for microphone clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -1449,7 +1449,7 @@ A device MAY implement both the `source` and `player` roles (e.g., a speaker wit
 
 A source client uses the same [clock synchronization](#clock-synchronization) mechanism as all clients. It timestamps each binary source audio message in the server time domain by inverting the filter's server-to-local mapping (`t_local = compute_client_time(t_server)`): for a capture at local time `t_capture` it sends the `t_server` that maps to it. The mapping is linear in the filter's offset and drift, so this inverse is well-defined; apply both offset and drift, not offset alone.
 
-**Unpaired access:** As `source@v1` exposes the server's audio stack to arbitrary input, activating it for an unauthenticated device requires explicit [approval](#unpaired-access). Approval implied by other use of the device, such as starting playback on it, does not extend to `source@v1`: the server leaves the role out of [`active_roles`](#server--client-serveractivate) until explicit approval. Clients with a privacy-sensitive input such as a microphone SHOULD ship with unpaired access disabled: the captured audio would otherwise be accessible to anyone on the network.
+**Unpaired access:** As `source@v1` exposes the server's audio stack to arbitrary input, activating it for an unauthenticated device requires explicit [approval](#unpaired-access). Approval implied by other use of the device, such as starting playback on it, does not extend to `source@v1`: the server leaves the role out of [`active_roles`](#server--client-serveractivate) until explicit approval.
 
 ### Client → Server: `client/hello` source@v1 support object
 

--- a/roles/source/v1.md
+++ b/roles/source/v1.md
@@ -7,7 +7,7 @@ A device MAY implement both the `source` and `player` roles (e.g., a speaker wit
 
 A source client uses the same [clock synchronization](../../messaging.md#clock-synchronization) mechanism as all clients. It timestamps each binary source audio message in the server time domain by inverting the filter's server-to-local mapping (`t_local = compute_client_time(t_server)`): for a capture at local time `t_capture` it sends the `t_server` that maps to it. The mapping is linear in the filter's offset and drift, so this inverse is well-defined; apply both offset and drift, not offset alone.
 
-**Unpaired access:** As `source@v1` exposes the server's audio stack to arbitrary input, activating it for an unauthenticated device requires explicit [approval](../../pairing.md#unpaired-access). Approval implied by other use of the device, such as starting playback on it, does not extend to `source@v1`: the server leaves the role out of [`active_roles`](../../messaging.md#server--client-serveractivate) until explicit approval. Clients with a privacy-sensitive input such as a microphone SHOULD ship with unpaired access disabled: the captured audio would otherwise be accessible to anyone on the network.
+**Unpaired access:** As `source@v1` exposes the server's audio stack to arbitrary input, activating it for an unauthenticated device requires explicit [approval](../../pairing.md#unpaired-access). Approval implied by other use of the device, such as starting playback on it, does not extend to `source@v1`: the server leaves the role out of [`active_roles`](../../messaging.md#server--client-serveractivate) until explicit approval.
 
 ### Client → Server: `client/hello` source@v1 support object
 


### PR DESCRIPTION
Removes the shipping-default recommendation added in #170:

> Clients with a privacy-sensitive input such as a microphone SHOULD ship with unpaired access disabled: the captured audio would otherwise be accessible to anyone on the network.

A device can ship with Sendspin off and enable it later through its own onboarding; that onboarding then owns the unpaired-access decision. Because this is client responsibility, the spec should not prescribe a shipping default.

The server-side protection is unchanged: activating `source@v1` on an unpaired connection still requires explicit operator approval, never implied approval.
